### PR TITLE
Database access for assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.1</version>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/au/org/democracydevelopers/raireservice/controller/AssertionController.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/controller/AssertionController.java
@@ -1,0 +1,35 @@
+package au.org.democracydevelopers.raireservice.controller;
+
+import au.org.democracydevelopers.raire.RaireSolution;
+import au.org.democracydevelopers.raireservice.request.ContestRequestByIDs;
+import au.org.democracydevelopers.raireservice.request.ContestRequestByName;
+import au.org.democracydevelopers.raireservice.service.CvrContestInfoService;
+import au.org.democracydevelopers.raireservice.service.GetAssertionsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequestMapping("/raire")
+@RequiredArgsConstructor
+public class AssertionController {
+
+  private final GetAssertionsService getAssertionsService;
+
+  /*
+  @PostMapping(path = "generate-assertions", produces = MediaType.APPLICATION_JSON_VALUE)
+  TODO
+  }
+  */
+
+  @PostMapping(path = "/get-assertions", produces = MediaType.APPLICATION_JSON_VALUE)
+  public RaireSolution serve(@RequestBody ContestRequestByName contest) {
+    log.info("Received request to get assertions for contest:  {}", contest.getContestName());
+    return getAssertionsService.getAssertions(contest);
+  }
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/controller/CvrContestInfoController.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/controller/CvrContestInfoController.java
@@ -1,7 +1,7 @@
 package au.org.democracydevelopers.raireservice.controller;
 
 import au.org.democracydevelopers.raire.RaireSolution;
-import au.org.democracydevelopers.raireservice.request.ContestRequest;
+import au.org.democracydevelopers.raireservice.request.OldContestRequest;
 import au.org.democracydevelopers.raireservice.service.CvrContestInfoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +20,7 @@ public class CvrContestInfoController {
   private final CvrContestInfoService cvrContestInfoService;
 
   @PostMapping(path = "audit", produces = MediaType.APPLICATION_JSON_VALUE)
-  public RaireSolution serve(@RequestBody ContestRequest contest) {
+  public RaireSolution serve(@RequestBody OldContestRequest contest) {
     log.info("Received request to audit contests with name: {}", contest.getContestName());
     return cvrContestInfoService.findCvrContestInfo(contest);
   }

--- a/src/main/java/au/org/democracydevelopers/raireservice/repository/AssertionRepository.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/repository/AssertionRepository.java
@@ -1,0 +1,12 @@
+package au.org.democracydevelopers.raireservice.repository;
+
+import au.org.democracydevelopers.raireservice.repository.entity.Assertion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AssertionRepository extends JpaRepository<Assertion, Long> {
+    List<Assertion> findByContestName(String contestName);
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/repository/converters/LongIntegerMapConverter.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/repository/converters/LongIntegerMapConverter.java
@@ -1,0 +1,54 @@
+package au.org.democracydevelopers.raireservice.repository.converters;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * A converter between maps from longs to integers and JSON
+ * representations of those maps, for database efficiency.
+ *
+ * Note: This has been copy-pasted from the file of the same name in colorado-rla.
+ */
+@Converter
+public class LongIntegerMapConverter
+  implements AttributeConverter<Map<Long, Integer>, String> {
+
+  /**
+   * The type information for a map.
+   */
+  private static final Type LONG_INTEGER_MAP =
+    new TypeToken<Map<Long, Integer>>() { }.getType();
+
+  /**
+   * Our Gson instance, which does not do pretty-printing (unlike the global
+   * one defined in Main).
+   */
+  private static final Gson GSON =
+    new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
+
+  /**
+   * Converts the specified list of Strings to a database column entry.
+   *
+   * @param the_set The list of Strings.
+   */
+  @Override
+  public String convertToDatabaseColumn(final Map<Long, Integer> the_map) {
+    return GSON.toJson(the_map);
+  }
+
+  /**
+   * Converts the specified database column entry to a list of strings.
+   *
+   * @param the_column The column entry.
+   */
+  @Override
+  public Map<Long, Integer> convertToEntityAttribute(final String the_column) {
+    return GSON.fromJson(the_column, LONG_INTEGER_MAP);
+  }
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/repository/converters/StringSetConverter.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/repository/converters/StringSetConverter.java
@@ -1,0 +1,66 @@
+/*
+ * Free & Fair Colorado RLA System
+ *
+ * @title ColoradoRLA
+ * @created Aug 26, 2017
+ * @copyright 2017 Colorado Department of State
+ * @license SPDX-License-Identifier: AGPL-3.0-or-later
+ * @creator Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @description A system to assist in conducting statewide risk-limiting audits.
+ */
+
+package au.org.democracydevelopers.raireservice.repository.converters;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+/**
+ * A converter between sets of Strings and JSON representations of those sets,
+ * for database efficiency.
+ *
+ * @author Daniel M. Zimmerman <dmz@freeandfair.us>
+ * @version 1.0.0
+ *
+ * Note: This has been copy-pasted from the file of the same name in colorado-rla.
+ */
+@Converter
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class StringSetConverter implements AttributeConverter<Set<String>, String> {
+  /**
+   * The type information for a set of String.
+   */
+  private static final Type STRING_SET = new TypeToken<Set<String>>() { }.getType();
+
+  /**
+   * Our Gson instance, which does not do pretty-printing (unlike the global
+   * one defined in Main).
+   */
+  private static final Gson GSON =
+      new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
+
+  /**
+   * Converts the specified list of Strings to a database column entry.
+   *
+   * @param the_set The list of Strings.
+   */
+  @Override
+  public String convertToDatabaseColumn(final Set<String> the_set) {
+    return GSON.toJson(the_set);
+  }
+
+  /**
+   * Converts the specified database column entry to a list of strings.
+   *
+   * @param the_column The column entry.
+   */
+  @Override
+  public Set<String> convertToEntityAttribute(final String the_column) {
+    return GSON.fromJson(the_column, STRING_SET);
+  }
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/repository/entity/Assertion.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/repository/entity/Assertion.java
@@ -1,0 +1,204 @@
+/*
+ * Sketch of abstract Assertion class (following conventions of other CORLA classes).
+ *
+ * Will need to implement PersistentEntity and Serializable interfaces, as shown.
+ *
+ * JPA hibernate annotations are speculative.
+ */
+
+/* This is very similar to the Assertion.java class in colorado-rla, with the Springboot upgrades copied from
+ * CDOS's SampleSizeDemoApplication.
+ * Function calls are not needed and have been removed.
+ */
+
+package au.org.democracydevelopers.raireservice.repository.entity;
+
+import au.org.democracydevelopers.raireservice.repository.converters.LongIntegerMapConverter;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Data
+@Entity
+@Table(name = "assertion")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "assertion_type")
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = NEBAssertion.class, name = "NEB"),
+        @JsonSubTypes.Type(value = NENAssertion.class, name = "NEN")
+})
+public abstract class Assertion {
+
+  /**
+   * Assertion ID.
+   */
+  @Id
+  @Column(updatable = false, nullable = false)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  private Long id;
+
+  /**
+   * The version (for optimistic locking).
+   */
+  @Version
+  private Long version;
+
+  /**
+   * Name of contest for which this Assertion was generated.
+   */
+  @Column(name = "contest_name", nullable = false)
+  protected String contestName;
+
+  /**
+   * Winner of the assertion (a candidate in the contest).
+   */
+  @Column(name = "winner", nullable = false)
+  protected String winner;
+
+  /**
+   * Loser of the assertion (a candidate in the contest).
+   */
+  @Column(name = "loser", nullable = false)
+  protected String loser;
+
+  /**
+   * Assertion margin.
+   */
+  @Column(name = "margin", nullable = false)
+  protected int margin;
+
+  /**
+   * Diluted margin for the assertion.
+   */
+  @Column(name = "diluted_margin", nullable = false)
+  protected double dilutedMargin = 0;
+
+  /**
+   * Assertion difficulty, as estimated by RAIRE.
+   */
+  @Column(name = "difficulty", nullable = false)
+  protected double difficulty = 0;
+
+  /**
+   * List of candidates that the assertion assumes are `continuing' in the
+   * assertion's context.
+   */
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name = "assertion_context",
+          joinColumns = @JoinColumn(name = "id"))
+  protected List<String> assumedContinuing = new ArrayList<>();
+
+  /**
+   * The number of samples to audit overall assuming no further overstatements.
+   */
+  @Column(nullable = false)
+  private Integer my_optimistic_samples_to_audit = 0;
+
+  /**
+   * Map between CVR ID and the discrepancy calculated for it (and its A-CVR) in the context
+   * of this assertion, based on the last call to computeDiscrepancy(). Calls to computeDiscrepancy()
+   * will update this map. Two options for how we persist this data. We can use existing
+   * functionality in colorado-rla (the LongIntegerMapConverter class). This will add a column to
+   * the assertion table. The second option is to create a new table: "assertion_cvr_discrepancy" which
+   * will have columns "id,crv_id,discrepancy", where "id" corresponds to this Assertion's ID, "cvr_id"
+   * to the ID of the CVR that is involved in the discrepancy, and "discrepancy" the value of the
+   * discrepancy from -2 to 2.
+   */
+  @Convert(converter = LongIntegerMapConverter.class)
+  @Column(columnDefinition = "text")
+  protected Map<Long,Integer> cvrDiscrepancy = new HashMap<>();
+
+  /**
+   * The expected number of samples to audit overall assuming overstatements
+   * continue at the current rate.
+   */
+  @Column(nullable = false)
+  private Integer my_estimated_samples_to_audit = 0;
+
+  /**
+   * The two-vote understatements recorded so far.
+   */
+  @Column(nullable = false)
+  protected Integer my_two_vote_under_count = 0;
+
+  /**
+   * The one-vote understatements recorded so far.
+   */
+  @Column(nullable = false)
+  protected Integer my_one_vote_under_count = 0;
+
+  /**
+   * The one-vote overstatements recorded so far.
+   */
+  @Column(nullable = false)
+  protected Integer my_one_vote_over_count = 0;
+
+  /**
+   * The two-vote overstatements recorded so far.
+   */
+  @Column(nullable = false)
+  protected Integer my_two_vote_over_count = 0;
+
+  /**
+   * Discrepancies recorded so far that are neither understatements nor overstatements.
+   */
+  @Column(nullable = false)
+  protected Integer my_other_count = 0;
+
+  /**
+   * Creates an Assertion for a specific contest. The assertion has a given winner, loser,
+   * margin, and list of candidates that are assumed to be continuing in the assertion's
+   * context.
+   *
+   * @param contestName       Assertion has been created for this contest.
+   * @param winner            Winning candidate (from contest contestID) of the assertion.
+   * @param loser             Losing candidate (from contest contestID) of the assertion.
+   * @param margin            Margin of the assertion.
+   * @param universeSize      Size of the universe for this audit, i.e. overall ballot count.
+   * @param difficulty        Estimated difficulty of assertion.
+   * @param assumedContinuing List of candidates that assertion assumes are continuing.
+   */
+  public Assertion(String contestName, String winner, String loser, int margin,
+                   long universeSize, double difficulty, List<String> assumedContinuing) {
+    this.contestName = contestName;
+    this.winner = winner;
+    this.loser = loser;
+    this.margin = margin;
+
+    assert universeSize != 0 : "Assertion constructor: can't work with zero universeSize.";
+    this.dilutedMargin = margin / (double) universeSize;
+
+    this.difficulty = difficulty;
+    this.assumedContinuing = assumedContinuing;
+  }
+
+    /**
+     * Construct an empty assertion (for persistence).
+     */
+  public Assertion(){}
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/repository/entity/NEBAssertion.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/repository/entity/NEBAssertion.java
@@ -1,0 +1,36 @@
+/*
+ * Sketch of NEBAssertion class (following conventions of other CORLA classes).
+ *
+ */
+
+package au.org.democracydevelopers.raireservice.repository.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+import java.util.*;
+
+
+/**
+ * Generic assertion for an assertion-based audit.
+ *
+ */
+@Entity
+@DiscriminatorValue("NEB")
+public class NEBAssertion extends Assertion  {
+
+  /**
+   * Construct an empty NEB assertion (for persistence).
+   */
+  public NEBAssertion(){
+    super();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public NEBAssertion(String contestName, String winner, String loser, int margin, long universeSize,
+                      double difficulty) {
+    super(contestName, winner, loser, margin, universeSize, difficulty,  new ArrayList<>());
+  }
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/repository/entity/NENAssertion.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/repository/entity/NENAssertion.java
@@ -1,0 +1,35 @@
+/*
+ * Sketch of NENAssertion class (following conventions of other CORLA classes).
+ *
+ */
+
+
+package au.org.democracydevelopers.raireservice.repository.entity;
+
+import java.util.List;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+/**
+ * Generic assertion for an assertion-based audit.
+ *
+ */
+@Entity
+@DiscriminatorValue("NEN")
+public class NENAssertion extends Assertion {
+
+  /**
+   * Construct an empty NEN assertion (for persistence).
+   */
+  public NENAssertion(){
+    super();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public NENAssertion(String contestName, String winner, String loser, int margin, long universeSize,
+                      double difficulty, List<String> assumedContinuing) {
+    super(contestName, winner, loser, margin, universeSize, difficulty, assumedContinuing);
+  }
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/request/ContestRequestByIDs.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/request/ContestRequestByIDs.java
@@ -1,0 +1,41 @@
+package au.org.democracydevelopers.raireservice.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.*;
+
+import static java.util.Arrays.stream;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ContestRequestByIDs {
+  private String contestName;
+  private int totalAuditableBallots;
+  private Integer timeProvisionForResult;
+  private String[] candidates;
+  private CountyAndContestIDs[] iDs;
+
+  /**
+   * Makes the metadata structure required for use by raire
+   * @returns a map from string to data which includes the relevant election metadata input to raire:
+   *  - candidates - a list of strings describing the candidate names
+   *  - contest - the name of the contest
+   *  - totalAuditableBallots - which allows for correct difficulty computations if the universe size is larger than
+   *    the number of ballots in this contest
+   */
+  public Map<String, Object> getMetadata() {
+    var candidatesAndMetadata = new HashMap<String, Object>();
+    candidatesAndMetadata.put("candidates", candidates);
+    candidatesAndMetadata.put("contest", contestName);
+    candidatesAndMetadata.put("totalAuditableBallots", totalAuditableBallots);
+    return candidatesAndMetadata;
+  }
+
+  private class CountyAndContestIDs {
+    Long countyID;
+    Long contestID;
+  }
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/request/ContestRequestByName.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/request/ContestRequestByName.java
@@ -1,0 +1,37 @@
+package au.org.democracydevelopers.raireservice.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ContestRequestByName {
+  private String contestName;
+  private int totalAuditableBallots;
+  private List<String> candidates;
+  private String winner;
+
+  /**
+   * Makes the metadata structure required for use by raire
+   * @returns a map from string to data which includes the relevant election metadata input to raire:
+   *  - candidates - a list of strings describing the candidate names
+   *  - contest - the name of the contest
+   *  - totalAuditableBallots - which allows for correct difficulty computations if the universe size is larger than
+   *    the number of ballots in this contest
+   */
+  // TODO Consider abstracting this into a superclass.
+  public Map<String, Object> getMetadata() {
+    var candidatesAndMetadata = new HashMap<String, Object>();
+    candidatesAndMetadata.put("candidates", candidates);
+    candidatesAndMetadata.put("contest", contestName);
+    candidatesAndMetadata.put("totalAuditableBallots", totalAuditableBallots);
+    candidatesAndMetadata.put("winner", winner);
+    return candidatesAndMetadata;
+  }
+}

--- a/src/main/java/au/org/democracydevelopers/raireservice/request/OldContestRequest.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/request/OldContestRequest.java
@@ -11,7 +11,7 @@ import static java.util.Arrays.stream;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class ContestRequest {
+public class OldContestRequest {
   private String contestName;
   private int totalAuditableBallots;
   private Integer timeProvisionForResult;

--- a/src/main/java/au/org/democracydevelopers/raireservice/service/CvrContestInfoService.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/service/CvrContestInfoService.java
@@ -5,7 +5,7 @@ import au.org.democracydevelopers.raire.RaireSolution;
 import au.org.democracydevelopers.raire.audittype.BallotComparisonOneOnDilutedMargin;
 import au.org.democracydevelopers.raire.pruning.TrimAlgorithm;
 import au.org.democracydevelopers.raire.util.VoteConsolidator;
-import au.org.democracydevelopers.raireservice.request.ContestRequest;
+import au.org.democracydevelopers.raireservice.request.OldContestRequest;
 
 import java.util.*;
 
@@ -29,7 +29,7 @@ public class CvrContestInfoService {
      * @param request a ContestRequest - a collection of IRV votes for a single contest, with metadata
      * @return a RaireSolution - the resulting collection of assertions, with metadata, or an error.
      */
-  public RaireSolution findCvrContestInfo(ContestRequest request) {
+  public RaireSolution findCvrContestInfo(OldContestRequest request) {
 
       List<String[]> votesByName = request.getVotes();
       VoteConsolidator consolidator = new VoteConsolidator(request.getCandidates());

--- a/src/main/java/au/org/democracydevelopers/raireservice/service/GetAssertionsService.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/service/GetAssertionsService.java
@@ -1,0 +1,109 @@
+package au.org.democracydevelopers.raireservice.service;
+
+import au.org.democracydevelopers.raire.RaireError;
+import au.org.democracydevelopers.raire.RaireSolution;
+import au.org.democracydevelopers.raire.algorithm.RaireResult;
+import au.org.democracydevelopers.raire.assertions.AssertionAndDifficulty;
+import au.org.democracydevelopers.raire.assertions.NotEliminatedBefore;
+import au.org.democracydevelopers.raire.assertions.NotEliminatedNext;
+import au.org.democracydevelopers.raireservice.repository.entity.Assertion;
+import au.org.democracydevelopers.raireservice.repository.AssertionRepository;
+import au.org.democracydevelopers.raireservice.repository.entity.NEBAssertion;
+import au.org.democracydevelopers.raireservice.repository.entity.NENAssertion;
+import au.org.democracydevelopers.raireservice.request.ContestRequestByName;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GetAssertionsService {
+
+    private final AssertionRepository assertionRepository;
+
+    /**
+     * The main method that actually does the work of this service. It
+     * - inputs a request, with a contest identified by name,
+     * - reads the relevant assertions from the database,
+     * - converts it into the format that an assertion visualiser expects, that is, a RaireSolution,
+     * - returns the result (or error).
+     * @param request a ContestRequestByName - name of a single contest, with metadata
+     * @return a RaireSolution - the resulting collection of assertions, with metadata, or an error.
+     */
+  public RaireSolution getAssertions(ContestRequestByName request) {
+
+      List<Assertion> assertions = assertionRepository.findByContestName(request.getContestName());
+      List<String> candidates = request.getCandidates();
+
+      // Convert assertions from database record into RAIRE export style with annotated difficulty.
+      AssertionAndDifficulty[] assertionsWithDifficulty =
+          assertions.stream().map(a ->
+              new AssertionAndDifficulty(makeRaireAssertion(a, candidates), a.getDifficulty(), a.getMargin())).toList()
+          .toArray(new AssertionAndDifficulty[0]);
+
+      // Find overall data: difficulty, margin, winner.
+      Optional<Assertion> maxDifficultyAssertion = assertions.stream().max(Comparator.comparingDouble(Assertion::getDifficulty));
+      Optional<Assertion> minMarginAssertion = assertions.stream().min(Comparator.comparingInt(Assertion::getMargin));
+      int overallWinner = request.getCandidates().indexOf(request.getWinner());
+
+      // Assertions present. Everything as expected. Build the RAIRE result to return.
+      if (assertionsWithDifficulty.length != 0 && maxDifficultyAssertion.isPresent() && minMarginAssertion.isPresent() && overallWinner != -1) {
+          log.debug(String.format("Assertions successfully retrieved from database for contest %s.", request.getContestName()));
+
+          RaireResult result = new RaireResult(
+                  assertionsWithDifficulty,
+                  maxDifficultyAssertion.get().getDifficulty(),
+                  minMarginAssertion.get().getMargin(),
+                  overallWinner,
+                  candidates.size());
+          // TODO Make useful metadata from stored info about which assertions have been confirmed.
+          Map<String, Object> metadata = Map.of("candidates", candidates);
+          return new RaireSolution(metadata, new RaireSolution.RaireResultOrError(result));
+
+          // TODO Improve error handling. We may not actually want a RAIRE error at this point, since it may be a
+          // database retrieval error.
+          // Indeed, it may not even be an error.  Distinguish empty assertion sets (which are not necessarily an error)
+          // from inconsistent ones (which certainly are an error).
+          // Build an empty RAIRE result to return.
+      } else  // if(assertionsWithDifficulty.length == 0) {
+      {
+          log.debug(String.format("No assertions present for contest %s.", request.getContestName()));
+          RaireResult result = new RaireResult(
+                  assertionsWithDifficulty,
+                  0,
+                  0,
+                  overallWinner,
+                  candidates.size());
+          // TODO Make useful metadata from stored info about which assertions have been confirmed.
+          Map<String, Object> metadata = Map.of("candidates", candidates);
+          return new RaireSolution(metadata, new RaireSolution.RaireResultOrError(result));
+      }
+  }
+
+    private au.org.democracydevelopers.raire.assertions.Assertion makeRaireAssertion(Assertion a, List<String> candidates) {
+
+      // Find index of winner, loser and (if relevant) continuing candidates in candidate list.
+      int winner = candidates.indexOf(a.getWinner());
+      int loser = candidates.indexOf(a.getLoser());
+      int[] continuing =  a.getAssumedContinuing().stream().mapToInt(candidates::indexOf).toArray();
+
+      // If it's an NEB assertion, return a RAIRE NEB assertion.
+      if( a instanceof NEBAssertion && winner != -1 && loser != -1) {
+        return new NotEliminatedBefore(winner, loser);
+
+        // If it's an NEN assertion, convert the continuing candidates to indices, then return the RAIRE NEN assertion.
+      } else if (a instanceof NENAssertion && winner != -1 && loser != -1 && Arrays.stream(continuing).noneMatch(i -> i == -1)) {
+          return new NotEliminatedNext(winner, loser, continuing);
+
+      } else {
+          // This obviously should not happen if all the assertions in the database are valid NEN or NEB. The check is important
+          // in case future versions of the software introduce other types of assertion.
+          log.error(String.format("Invalid assertion retrieved from database: %s", a));
+          throw new RuntimeException(String.format("Invalid assertion retrieved from database: %s", a));
+      }
+    }
+}

--- a/src/test/java/au/org/democracydevelopers/raireservice/ContestRequestTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/ContestRequestTests.java
@@ -1,6 +1,6 @@
 package au.org.democracydevelopers.raireservice;
 
-import au.org.democracydevelopers.raireservice.request.ContestRequest;
+import au.org.democracydevelopers.raireservice.request.OldContestRequest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -18,8 +18,8 @@ class ContestRequestTests {
      */
     void validVoteListIsValid () {
         List<String[]> testVotes = List.of(v1,v2);
-        ContestRequest testValidRequest
-                = new ContestRequest("TestContest", 10, 10, testCandidates, testVotes );
+        OldContestRequest testValidRequest
+                = new OldContestRequest("TestContest", 10, 10, testCandidates, testVotes );
         assert testValidRequest.votesAreValid();
     }
 
@@ -29,8 +29,8 @@ class ContestRequestTests {
      */
     void invalidVoteListIsNotValid () {
         List<String[]> testVotesInvalid = List.of(v1,v2,v3);
-        ContestRequest testValidRequest
-                = new ContestRequest("TestContest", 10, 10, testCandidates, testVotesInvalid );
+        OldContestRequest testValidRequest
+                = new OldContestRequest("TestContest", 10, 10, testCandidates, testVotesInvalid );
         assert !testValidRequest.votesAreValid();
     }
 
@@ -43,8 +43,8 @@ class ContestRequestTests {
      */
     void invalidCandidateNameIsNotNoticed () {
         List<String[]> testVotesInvalid = List.of(v1,v2,v4);
-        ContestRequest testValidRequest
-                = new ContestRequest("TestContest", 10, 10, testCandidates, testVotesInvalid );
+        OldContestRequest testValidRequest
+                = new OldContestRequest("TestContest", 10, 10, testCandidates, testVotesInvalid );
         assert testValidRequest.votesAreValid();
     }
 

--- a/src/test/java/au/org/democracydevelopers/raireservice/GetAssertionsTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/GetAssertionsTests.java
@@ -1,0 +1,125 @@
+package au.org.democracydevelopers.raireservice;
+
+import au.org.democracydevelopers.raire.RaireSolution;
+import au.org.democracydevelopers.raire.algorithm.RaireResult;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * Tests for Springboot functioning. This class automatically fires up the RAIRE Microservice on a random port, then runs
+ * a series of (at this stage) very basic tests.
+ * Note that you have to run the *whole class*. Individual tests do not work separately because they don't initiate the
+ * microservice on their own.
+ */
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GetAssertionsTests {
+
+    private final static String auditEndpoint = "/raire/get-assertions";
+
+    @LocalServerPort
+    private int port;
+
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void contextLoads() {
+    }
+
+    /*
+     * This is really just a test that the testing is working.
+     * There's no mapping for the plain localhost response, so when the microservice is running it just returns
+     * a default error. We check for 404 because that appears in the default error text.
+     */
+    @Test
+    public void testErrorForNonFunctioningEndpoint() {
+        assertTrue((restTemplate.getForObject("http://localhost:" + port + "/",
+                String.class)).contains("404"));
+    }
+
+    /*
+     * Check that calling the right endpoint with no header and no data produces a sensible error message.
+     */
+    @Test
+    public void testMethodNotAllowed() {
+        assertTrue((restTemplate.getForObject("http://localhost:" + port + auditEndpoint,
+                String.class)).contains("405"));
+        assertTrue((restTemplate.getForObject("http://localhost:" + port + auditEndpoint,
+                String.class)).contains("Method Not Allowed"));
+    }
+
+    /*
+     * The right endpoint, with correct headers but no data, should produce "Bad Request".
+     */
+    @Test
+    public void testBadRequest() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String url = "http://localhost:" + port + auditEndpoint;
+
+        HttpEntity<String> request = new HttpEntity<>("", headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+
+        assertTrue(Objects.requireNonNull(response.getBody()).contains("400"));
+        assertTrue(response.getBody().contains("Bad Request"));
+    }
+
+    /*
+     * At this stage, we are only testing that we get a solution.
+     */
+    @Test
+    public void testTrivialExample() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String url = "http://localhost:" +port + auditEndpoint;
+
+        HttpEntity<String> request = new HttpEntity<>("{\"contestName\": \"TrivialExample1\", " +
+                "\"totalAuditableBallots\": 15, " +
+                " \"candidates\": [\"Alice\",\"Bob\"], " +
+                " \"winner\": \"Alice\" " +
+                "}", headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class );
+
+        assertTrue(Objects.requireNonNull(response.getBody()).contains("solution"));
+    }
+
+    /*
+     * Test that the assertion list for a nonexistent contest is empty.
+     * Note: FIXME This test is deliberately buggy for now, because I want to test the new testing automation.
+     */
+    @Test
+    public void testNonexistentExample() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String url = "http://localhost:" +port + auditEndpoint;
+
+        HttpEntity<String> request = new HttpEntity<>("{\"contestName\": \"ImpossibleCantBeRealContestName982389273428\", " +
+                "\"totalAuditableBallots\": 15, " +
+                " \"candidates\": [\"Alice\",\"Bob\"], " +
+                " \"winner\": \"Alice\" " +
+                "}", headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class );
+
+        Gson gson = new Gson();
+        String jsonString = response.getBody();
+        RaireSolution result = gson.fromJson(jsonString, RaireSolution.class);
+
+        // Actually this is the opposite of what should be true, just for testing the testing.
+        assertTrue(result.solution.Ok.assertions.length != 0);
+    }
+}


### PR DESCRIPTION
This will eventually be the branch that shifts database access and retrieval into the raire-service, rather than colorado-rla.

For now, I've just made a very basic start on retrieving assertions from the database.

More importantly, I've deliberately added a failing test, in order to test the new auto-testing suite set up by @michelleblom 