### PR TITLE
Get assertions updates

### DIFF
--- a/src/main/java/au/org/democracydevelopers/raireservice/service/GetAssertionsCsvService.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/service/GetAssertionsCsvService.java
@@ -94,7 +94,7 @@ public class GetAssertionsCsvService {
       String extrema = findExtrema(sortedAssertions);
       String headers = escapeThenJoin(csvHeaders);
       String contents = makeContents(sortedAssertions, request.candidates);
-      String notes = NOTES + "," + SAMPLE_SIZE_NOTE + "\n," + RISK_NOTE_1 + "\n," + RISK_NOTE_2 + "\n";
+      String notes = makeNotes();
 
       logger.debug(String.format("%s %d assertions translated to csv.", prefix, assertions.size()));
       return preface + extrema + "\n\n" + headers + "\n" + contents + "\n\n" + notes;
@@ -108,6 +108,15 @@ public class GetAssertionsCsvService {
           prefix, e.getMessage()));
       throw new RaireServiceException(e.getMessage(), RaireErrorCode.INTERNAL_ERROR);
     }
+  }
+
+  /**
+   * Make the notes about sample sizes and risks - these are just hardcoded.
+   * @return the csv-formatted strings for the notes.
+   */
+  private String makeNotes() {
+    return NOTES + ",\""
+        + String.join("\"\n,\"", List.of(SAMPLE_SIZE_NOTE, RISK_NOTE_1, RISK_NOTE_2)) + "\"\n";
   }
 
   /**

--- a/src/main/java/au/org/democracydevelopers/raireservice/service/GetAssertionsCsvService.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/service/GetAssertionsCsvService.java
@@ -21,19 +21,7 @@ raire-service. If not, see <https://www.gnu.org/licenses/>.
 package au.org.democracydevelopers.raireservice.service;
 
 import static au.org.democracydevelopers.raireservice.persistence.entity.GenerateAssertionsSummary.UNKNOWN_WINNER;
-import static au.org.democracydevelopers.raireservice.service.Metadata.CANDIDATES_HEADER;
-import static au.org.democracydevelopers.raireservice.service.Metadata.CONTEST_NAME_HEADER;
-import static au.org.democracydevelopers.raireservice.service.Metadata.CURRENT_RISK;
-import static au.org.democracydevelopers.raireservice.service.Metadata.DIFFICULTY;
-import static au.org.democracydevelopers.raireservice.service.Metadata.DILUTED_MARGIN;
-import static au.org.democracydevelopers.raireservice.service.Metadata.ESTIMATED_SAMPLES;
-import static au.org.democracydevelopers.raireservice.service.Metadata.MARGIN;
-import static au.org.democracydevelopers.raireservice.service.Metadata.OPTIMISTIC_SAMPLES;
-import static au.org.democracydevelopers.raireservice.service.Metadata.RISK_LIMIT_HEADER;
-import static au.org.democracydevelopers.raireservice.service.Metadata.TOTAL_AUDITABLE_BALLOTS_HEADER;
-import static au.org.democracydevelopers.raireservice.service.Metadata.WINNER_HEADER;
-import static au.org.democracydevelopers.raireservice.service.Metadata.extremumHeaders;
-import static au.org.democracydevelopers.raireservice.service.Metadata.csvHeaders;
+import static au.org.democracydevelopers.raireservice.service.Metadata.*;
 import static au.org.democracydevelopers.raireservice.service.RaireServiceException.RaireErrorCode.NO_ASSERTIONS_PRESENT;
 import static au.org.democracydevelopers.raireservice.util.CSVUtils.escapeThenJoin;
 import static au.org.democracydevelopers.raireservice.util.CSVUtils.intListToString;
@@ -106,9 +94,10 @@ public class GetAssertionsCsvService {
       String extrema = findExtrema(sortedAssertions);
       String headers = escapeThenJoin(csvHeaders);
       String contents = makeContents(sortedAssertions, request.candidates);
+      String notes = NOTES + "," + SAMPLE_SIZE_NOTE + "\n," + RISK_NOTE_1 + "\n," + RISK_NOTE_2 + "\n";
 
       logger.debug(String.format("%s %d assertions translated to csv.", prefix, assertions.size()));
-      return preface + extrema + "\n\n" + headers + "\n" + contents;
+      return preface + extrema + "\n\n" + headers + "\n" + contents + "\n\n" + notes;
 
     } catch(RaireServiceException ex) {
       logger.error(String.format("%s RaireServiceException caught. Passing to caller: %s",

--- a/src/main/java/au/org/democracydevelopers/raireservice/service/GetAssertionsJsonService.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/service/GetAssertionsJsonService.java
@@ -38,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import static au.org.democracydevelopers.raireservice.service.Metadata.*;
+
 /**
  * Collection of functions responsible for retrieving assertions from the colorado-rla database,
  * through the use of an AssertionRepository, and packaging them in a form suitable for export
@@ -93,6 +95,7 @@ public class GetAssertionsJsonService {
       metadata.put(Metadata.RISK_LIMIT, request.riskLimit);
       metadata.put(Metadata.CONTEST, request.contestName);
       metadata.put(Metadata.TOTAL_BALLOTS, request.totalAuditableBallots);
+      metadata.put(Metadata.NOTES, List.of(RISK_NOTE_1, RISK_NOTE_2));
 
       // Translate the assertions extracted from the database into AssertionAndDifficulty objects,
       // keeping track of the maximum difficulty and minimum margin.

--- a/src/main/java/au/org/democracydevelopers/raireservice/service/Metadata.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/service/Metadata.java
@@ -101,25 +101,25 @@ public class Metadata {
    * Notes about some counterintuitive features of the CSV and JSON data, 1: Sample sizes are
    * initially zero, if sample size estimation hasn't run. This deserves a warning.
    */
-  public final static String SAMPLE_SIZE_NOTE = "\"Optimistic and Estimated sample sizes will show " +
+  public final static String SAMPLE_SIZE_NOTE = "Optimistic and Estimated sample sizes will show " +
       "zero if sample size estimation has not been run. If they still show zero after running sample " +
-      "size estimation, it means the contest is not auditable.\"";
+      "size estimation, it means the contest is not auditable.";
 
   /**
    * Notes about some counterintuitive features of the CSV and JSON data, 2: Risk assessments may be
    * inaccurate if the contest was not targeted.
    */
-  public final static String RISK_NOTE_1 = "\"For cross-county non-targeted contests, colorado-rla does not guarantee " +
+  public final static String RISK_NOTE_1 = "For cross-county non-targeted contests, colorado-rla does not guarantee " +
       "a uniform sample. In this case, the risk value is not meaningful. Risk values for targeted contests " +
-      "and single-county contests are accurate.\"";
+      "and single-county contests are accurate.";
 
   /**
    * Notes about some counterintuitive features of the CSV and JSON data, 3: Risk assessments may be
    * high simply because not many samples were taken - it doesn't mean there's a high risk of a wrong
    * outcome.
    */
-  public final static String RISK_NOTE_2 = "\"Non-targeted contests may have high apparent risks " +
-      "simply because there were not many samples of that contest---they are not expected to meet the risk limit.\"";
+  public final static String RISK_NOTE_2 = "Non-targeted contests may have high apparent risks " +
+      "simply because there were not many samples of that contest---they are not expected to meet the risk limit.";
 
 
   // Other headers used in parts of the csv

--- a/src/main/java/au/org/democracydevelopers/raireservice/service/Metadata.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/service/Metadata.java
@@ -86,12 +86,41 @@ public class Metadata {
    */
   public final static String OPTIMISTIC_SAMPLES = "Optimistic samples to audit";
 
-
   /**
    * The estimated samples to audit. Colorado-rla calculates this, and we retrieve it from the
    * database.
    */
   public final static String ESTIMATED_SAMPLES = "Estimated samples to audit";
+
+  /**
+   * Notes to go at the end.
+   */
+  public final static String NOTES = "Notes";
+
+  /**
+   * Notes about some counterintuitive features of the CSV and JSON data, 1: Sample sizes are
+   * initially zero, if sample size estimation hasn't run. This deserves a warning.
+   */
+  public final static String SAMPLE_SIZE_NOTE = "\"Optimistic and Estimated sample sizes will show " +
+      "zero if sample size estimation has not been run. If they still show zero after running sample " +
+      "size estimation, it means the contest is not auditable.\"";
+
+  /**
+   * Notes about some counterintuitive features of the CSV and JSON data, 2: Risk assessments may be
+   * inaccurate if the contest was not targeted.
+   */
+  public final static String RISK_NOTE_1 = "\"For cross-county non-targeted contests, colorado-rla does not guarantee " +
+      "a uniform sample. In this case, the risk value is not meaningful. Risk values for targeted contests " +
+      "and single-county contests are accurate.\"";
+
+  /**
+   * Notes about some counterintuitive features of the CSV and JSON data, 3: Risk assessments may be
+   * high simply because not many samples were taken - it doesn't mean there's a high risk of a wrong
+   * outcome.
+   */
+  public final static String RISK_NOTE_2 = "\"Non-targeted contests may have high apparent risks " +
+      "simply because there were not many samples of that contest---they are not expected to meet the risk limit.\"";
+
 
   // Other headers used in parts of the csv
   public final static String CONTEST_NAME_HEADER = "Contest name";


### PR DESCRIPTION
This adds some notes to the assertions in both json and csv, to explain some otherwise-unintuitive data values.