### PR TITLE
108 generate assertions summary database row doesn't update from failure to success

### DIFF
--- a/src/main/java/au/org/democracydevelopers/raireservice/persistence/entity/GenerateAssertionsSummary.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/persistence/entity/GenerateAssertionsSummary.java
@@ -130,7 +130,10 @@ public class GenerateAssertionsSummary {
    * @param message the message associated with the error (e.g. the names of tied winners).
    * @throws RaireServiceException if the error is blank.
    */
-  public void update(String error, String message) throws RaireServiceException {
+  public GenerateAssertionsSummary(String contestName, String error, String message) throws RaireServiceException {
+  // public void update(String error, String message) throws RaireServiceException {
+    this(contestName);
+
     final String prefix = "[update]";
     logger.debug(String.format("%s %s %s.", prefix, "Updating error summary for contest ",
         contestName));
@@ -162,8 +165,11 @@ public class GenerateAssertionsSummary {
    *                     raire's response.
    * @throws RaireServiceException if the winnerIndex is not valid for the size of the candidate list.
    */
-  public void update(List<String> candidates, int winnerIndex, boolean trimTimedOut)
+  public GenerateAssertionsSummary(String contestName, List<String> candidates, int winnerIndex, boolean trimTimedOut)
+  // public void update(List<String> candidates, int winnerIndex, boolean trimTimedOut)
                                                                     throws RaireServiceException {
+    this(contestName);
+
     final String prefix = "[update]";
     logger.debug(String.format("%s %s %s.", prefix, "Updating winner summary for contest ",
         contestName));
@@ -183,7 +189,6 @@ public class GenerateAssertionsSummary {
       logger.debug(String.format("%s %s", prefix, msg));
       throw new RaireServiceException(msg, INTERNAL_ERROR);
     }
-
   }
 
   /**
@@ -225,4 +230,9 @@ public class GenerateAssertionsSummary {
    * @return the message associated with the error.
    */
   public String getMessage() {return message;}
+
+  /**
+   * @return the ID.
+   */
+  public long getId() {return id;}
 }

--- a/src/main/java/au/org/democracydevelopers/raireservice/persistence/entity/GenerateAssertionsSummary.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/persistence/entity/GenerateAssertionsSummary.java
@@ -105,7 +105,7 @@ public class GenerateAssertionsSummary {
    * @param contestName Contest for which the Assertion has been created.
    * @throws RaireServiceException if the given contestName is blank.
    */
-  public GenerateAssertionsSummary(String contestName) throws RaireServiceException {
+  public GenerateAssertionsSummary(final String contestName) throws RaireServiceException {
     final String prefix = "[Generate Assertions Summary initial constructor]";
     logger.debug(String.format("%s Parameters: contest name %s; winner %s; error %s; warning %s.",
         prefix, contestName, winner, error, warning));
@@ -123,24 +123,20 @@ public class GenerateAssertionsSummary {
   }
 
   /**
-   * Update error data, remove winner and warnings, when assertion generation failed. Intended for
-   * initialization, and for subsequent runs of Generate Assertions, for the same contest, when
-   * assertion generation failed.
+   * Constructor, for failed assertion generation summary.
    * @param error   the error, if any.
    * @param message the message associated with the error (e.g. the names of tied winners).
    * @throws RaireServiceException if the error is blank.
    */
-  public GenerateAssertionsSummary(String contestName, String error, String message) throws RaireServiceException {
-  // public void update(String error, String message) throws RaireServiceException {
-    this(contestName);
+  public GenerateAssertionsSummary(final String contestName, final String error,
+                                   final String message) throws RaireServiceException {
 
+    this(contestName);
     final String prefix = "[update]";
-    logger.debug(String.format("%s %s %s.", prefix, "Updating error summary for contest ",
-        contestName));
 
     // There should not be both a winner and an error. (It's OK to have a winner and a warning.)
     if(error.isBlank()) {
-      String msg = String.format("%s Attempt to build or update GenerateAssertionsResponseOrError " +
+      final String msg = String.format("%s Attempt to build or update GenerateAssertionsResponseOrError " +
           "using the error constructor with a blank error.", prefix);
       logger.error(msg);
       throw new RaireServiceException(msg, RaireServiceException.RaireErrorCode.INTERNAL_ERROR);
@@ -151,42 +147,37 @@ public class GenerateAssertionsSummary {
     this.warning = "";
     this.message = message;
 
-    logger.debug(String.format("%s Successful update of summary for contest %s, error %s, message %s.",
-        prefix, contestName, error, message));
+    logger.debug(String.format("%s Created summary for failed assertion generation:  " +
+            "contest %s, error %s, message %s.", prefix, contestName, error, message));
   }
 
   /**
-   * Update summary data, remove errors and associated messages, when Assertion Generation Succeeded.
-   * Intended for initialization, and for subsequent runs of Generate Assertions for the same
-   * contest.
+   * Constructor, for successful assertion generation summary.
    * @param candidates   The candidate list submitted in the Generate Assertions request.
    * @param winnerIndex  The index of the winner, in the candidate list.
    * @param trimTimedOut Indication of whether the warning_trim_timed_out flag was present in
    *                     raire's response.
    * @throws RaireServiceException if the winnerIndex is not valid for the size of the candidate list.
    */
-  public GenerateAssertionsSummary(String contestName, List<String> candidates, int winnerIndex, boolean trimTimedOut)
-  // public void update(List<String> candidates, int winnerIndex, boolean trimTimedOut)
-                                                                    throws RaireServiceException {
+  public GenerateAssertionsSummary(final String contestName, final List<String> candidates,
+              final int winnerIndex, final boolean trimTimedOut) throws RaireServiceException {
     this(contestName);
+    final String prefix = "[GenerateAssertionsSummary]";
 
-    final String prefix = "[update]";
-    logger.debug(String.format("%s %s %s.", prefix, "Updating winner summary for contest ",
-        contestName));
     try {
       winner = candidates.get(winnerIndex);
       error = "";
       warning = trimTimedOut ? TIMEOUT_TRIMMING_ASSERTIONS.toString() : "";
       message = "";
 
-      logger.debug(String.format("%s Successful update of summary for contest %s, winner %s, trim time out %s.",
-          prefix, contestName, winner, trimTimedOut));
+      logger.debug(String.format("%s Created summary for successful assertion generation: " +
+              "contest %s, winner %s, trim time out %s.", prefix, contestName, winner, trimTimedOut));
     } catch (IndexOutOfBoundsException e) {
       // The winner's index was out of bounds. This can happen if the winner isn't present in the set
       // of candidates in the request.
-      String msg = String.format("Invalid winner when updating summary for contest %s, winner %d, trim time out %s," +
+      final String msg = String.format("Invalid winner when creating summary for contest %s, winner %d, trim time out %s," +
               "candidate list %s.", contestName, winnerIndex, trimTimedOut, candidates);
-      logger.debug(String.format("%s %s", prefix, msg));
+      logger.error(String.format("%s %s", prefix, msg));
       throw new RaireServiceException(msg, INTERNAL_ERROR);
     }
   }
@@ -202,8 +193,8 @@ public class GenerateAssertionsSummary {
    * @return true if contestname, winner, error and warning all match, and messageSubstring is
    * a substring of message.
    */
-  public boolean equalData(String contestName, String winner,
-                           String error, String warning, String messageSubstring) {
+  public boolean equalData(final String contestName, final String winner,
+                           final String error, final String warning, final String messageSubstring) {
     return this.contestName.equals(contestName)
         && this.winner.equals(winner)
         && this.error.equals(error)

--- a/src/main/java/au/org/democracydevelopers/raireservice/persistence/repository/GenerateAssertionsSummaryRepository.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/persistence/repository/GenerateAssertionsSummaryRepository.java
@@ -25,9 +25,11 @@ import au.org.democracydevelopers.raireservice.persistence.entity.GenerateAssert
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -48,4 +50,13 @@ public interface GenerateAssertionsSummaryRepository extends JpaRepository<Gener
   @Query(value="select a from GenerateAssertionsSummary a where a.contestName = :contestName")
   Optional<GenerateAssertionsSummary> findByContestName(@Param("contestName") String contestName);
 
+  /**
+   * Delete all summaries (there should be at most one) belonging to the contest with the given name
+   * from the database. This is Spring syntactic sugar for the corresponding 'delete' query.
+   * @param contestName The name of the contest whose assertions are to be deleted.
+   */
+  @Query(value="delete from GenerateAssertionsSummary a where a.contestName = :contestName")
+  @Modifying
+  @Transactional
+  void deleteByContestName(@Param("contestName") String contestName);
 }

--- a/src/main/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsService.java
+++ b/src/main/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsService.java
@@ -202,7 +202,7 @@ public class GenerateAssertionsService {
    * If the result contains an error or warning, persist it and its message in the
    * GenerateAssertionsResponse table.
    * Previously-stored assertions are deleted, regardless of whether assertion generation
-   * was successful this time. Previously-stored summaries are updated.
+   * was successful this time. Previously-stored summaries are replaced.
    * @param solution RaireResultOrError containing either assertions to persist for a given contest,
    *                 with a winner, or an error. Note that there may be both a warning and successful
    *                 assertion generation.
@@ -218,29 +218,13 @@ public class GenerateAssertionsService {
    *
    */
   @Transactional(rollbackOn = {RuntimeException.class, DataAccessException.class, RaireServiceException.class})
-  public void persistAssertionsOrErrors(RaireResultOrError solution, ContestRequest request)
+  public void persistAssertionsOrErrors(final RaireResultOrError solution, final ContestRequest request)
       throws RaireServiceException {
     final String prefix = "[persistAssertionsOrErrors]";
 
-
-    // FIXME all this can be deleted and replaced with a one-liner that deletes the summary by contest name.
-    // Retrieve an existing summary or start a new one.
     GenerateAssertionsSummary summary;
-    /*
-    final Optional<GenerateAssertionsSummary> OptSummary
-        = summaryRepository.findByContestName(request.contestName);
-    if (OptSummary.isPresent() && summaryRepository.findById(OptSummary.get().getId()).isPresent()) {
-      // A summary is already present in the database - we will update this.
-      summary = summaryRepository.findById(OptSummary.get().getId()).get();
-      // Delete any existing summaries for this contest.
-      // FIXME - just write a deleteByContestName function.
-      summaryRepository.deleteById(summary.getId());
-    } else {
-      // There is no summary for this contest - make a new blank summary.
-      summary = new GenerateAssertionsSummary(request.contestName);
-    }
-    */
 
+    // Delete the old summary.
     summaryRepository.deleteByContestName(request.contestName);
 
     // Delete any existing assertions for this contest.
@@ -249,7 +233,7 @@ public class GenerateAssertionsService {
     assertionRepository.deleteByContestName(request.contestName);
 
     if (solution.Ok != null) {
-      // The solution is OK. Persist assertions formed by raire-java and save the winner and warning.
+      // The solution is OK. Persist assertions formed by raire-java and save the winner and warning (if any).
       logger.debug(String.format("%s Proceeding to translate and save %d assertions to the " +
           "database for contest %s.", prefix, solution.Ok.assertions.length, request.contestName));
       assertionRepository.translateAndSaveAssertions(request.contestName,
@@ -257,29 +241,33 @@ public class GenerateAssertionsService {
 
       logger.debug(String.format("%s Assertions persisted.", prefix));
 
-      // Update summary data, success.
-      summary = new GenerateAssertionsSummary(request.contestName, request.candidates, solution.Ok.winner, solution.Ok.warning_trim_timed_out);
+      // Make a new summary with success info.
+      summary = new GenerateAssertionsSummary(request.contestName, request.candidates,
+          solution.Ok.winner, solution.Ok.warning_trim_timed_out);
 
     } else if (solution.Err != null) {
       // The solution indicates a failed assertion generation. Persist the error and message.
+      logger.debug(String.format("%s Assertion generation failed with error %s for contest %s. " +
+          "Replacing generate assertions summary and deleting any prior assertions.", prefix,
+          solution.Err, request.contestName));
 
       // Creating a RaireServiceException gives us a human-readable error message, though the
       // exception is not thrown.
-      RaireServiceException ex = new RaireServiceException(solution.Err, request.candidates);
+      final RaireServiceException ex = new RaireServiceException(solution.Err, request.candidates);
 
-      // Update summary data.
+      // Make a new summary with failure info.
       summary = new GenerateAssertionsSummary(request.contestName, ex.errorCode.toString(), ex.getMessage());
-      // summary.update(ex.errorCode.toString(), ex.getMessage());
+
     } else {
       // This is not supposed to happen - we got neither assertions nor an error.
-      summary = new GenerateAssertionsSummary(request.contestName, INTERNAL_ERROR.toString(), "Internal error");
-      // summary.update(INTERNAL_ERROR.toString(), "Internal error");
+      logger.debug(String.format("%s Assertion generation failed with an internal error for contest %s. " +
+          "Replacing generate assertions summary and deleting any prior assertions.", prefix,
+          request.contestName));
+
+      summary = new GenerateAssertionsSummary(request.contestName, INTERNAL_ERROR.toString(),
+          "Internal error");
     }
 
-    // This throws an exception (and anyway is redundant) if the summary already existed, but is
-    // necessary if we made a new summary.
-    // if(OptSummary.isEmpty()) {
-      summaryRepository.save(summary);
-    // }
+    summaryRepository.save(summary);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none # When you launch the application for the first time - switch "none" at "create"
-    show-sql: false
+    show-sql: true
     database: postgresql
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false

--- a/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIMultipleCallsTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIMultipleCallsTests.java
@@ -27,6 +27,7 @@ import au.org.democracydevelopers.raire.assertions.NotEliminatedBefore;
 import au.org.democracydevelopers.raireservice.request.GenerateAssertionsRequest;
 import au.org.democracydevelopers.raireservice.request.GetAssertionsRequest;
 import au.org.democracydevelopers.raireservice.response.GenerateAssertionsResponse;
+import au.org.democracydevelopers.raireservice.service.Metadata;
 import au.org.democracydevelopers.raireservice.service.RaireServiceException.RaireErrorCode;
 import au.org.democracydevelopers.raireservice.testUtils;
 import au.org.democracydevelopers.raireservice.util.DoubleComparator;
@@ -51,6 +52,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static au.org.democracydevelopers.raireservice.NSWValues.BallotCount_12;
+import static au.org.democracydevelopers.raireservice.NSWValues.choicesContest_12;
+import static au.org.democracydevelopers.raireservice.controller.GenerateAssertionsAPIWickedTests.ByronMayoral;
+import static au.org.democracydevelopers.raireservice.service.GenerateAssertionsServiceMultipleCallsTests.ByronNormalTimeoutRequest;
 import static au.org.democracydevelopers.raireservice.service.RaireServiceException.ERROR_CODE_KEY;
 import static au.org.democracydevelopers.raireservice.testUtils.correctAssertionData;
 import static au.org.democracydevelopers.raireservice.testUtils.correctMetadata;
@@ -58,25 +63,22 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests to validate the behaviour of the Assertion generation API when called successively.
+ * These are the same as the tests in GenerateAssertionsServiceMultipleCallsTests.java, but use
+ * the API instead of a call to the service.
  * Relevant data is preloaded into the test database from
  * src/test/resources/known_testcases_votes.sql.
  * These tests include
- * 1. Calling the endpoint twice with no parameters. The state at the end of the second call should be
- *   the same as at the end of the first.
+ * 1. Calling the endpoint twice with the same contest name. The state at the end of the second call
+ * should be the same as at the end of the first.
  * 2. Calling the endpoint first with an extremely small time limit that causes assertion generation
- *   to fail, then calling it again with a longer time limit that succeeds. This should store
- *   assertions and replace the summary.
- * 3. Calling the endpoint first with a tied contest, then again with altered CVRs that don't tie.
- *   This should store assertions and replace the summary.
- * 4. The same as (2), but in the opposite order.
- * 5. The same as (3), but in the opposite order.
+ * to fail, then calling it again with a longer time limit that succeeds. This should store
+ * assertions and replace the summary.
+ * 3. The same as (2), but in the opposite order.
  * In each case, the test
  * - makes a request for assertion generation through the API,
- * - checks for the right winner,
+ * - checks for the right winner or the expected error,
  * - requests the assertion data through the get-assertions API (JSON),
- * TODO - better get the summaries somehow - dashboard? - or should we be reading the DB to see what's there?
- * - verifies the expected difficulty,
- * and checks for the expected data.
+ * - checks whether there are assertions for the contest.
  */
 @ActiveProfiles("known-testcases")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -118,29 +120,22 @@ public class GenerateAssertionsAPIMultipleCallsTests {
    */
   private static final String[] aliceChuanBob = {"Alice", "Chuan", "Bob"};
 
+  private static final GetAssertionsRequest ByronGetAssertionsRequest
+      = new GetAssertionsRequest(ByronMayoral, BallotCount_12, choicesContest_12, DEFAULT_RISK_LIMIT);
+
   /**
-   * Test the first example in the Guide to Raire Part 2.
-   * The test data has 1/500 of the votes, so divide margins by 500.
-   * The difficulties should be the same, because both numerator and denominator should be divided by 500.
-   * We do not test the NEN assertions because the ones in the Guide have some redundancy.
-   * Test assertion: Chuan NEB Bob.
-   * Margin is 4000, but data is divided by 500, so 8. Difficulty is 3.375 as in the Guide.
-   * Diluted margin is 8/27 = 0.296...
+   * Run Byron Mayoral assertion generation twice; sanity-check results.
    */
   @Test
   @Transactional
-  public void testGuideToRairePart2Example1() {
-    testUtils.log(logger, "testGuideToRairePart2Example1");
+  public void ByronRunsTwiceSameResults() {
+    testUtils.log(logger, "ByronRunsTwiceSameResults");
     String generateUrl = baseURL + port + generateAssertionsEndpoint;
     String getUrl = baseURL + port + getAssertionsEndpoint;
 
-    GenerateAssertionsRequest request = new GenerateAssertionsRequest(guideToRaireExample1,
-        27, DEFAULT_TIME_LIMIT, Arrays.stream(aliceBobChuanDiego).toList());
-
-
     // Request for the assertions to be generated.
     ResponseEntity<GenerateAssertionsResponse> response = restTemplate.postForEntity(generateUrl,
-        request, GenerateAssertionsResponse.class);
+        ByronNormalTimeoutRequest, GenerateAssertionsResponse.class);
 
     // Check that generation is successful, with no retry.
     assertTrue(response.getStatusCode().is2xxSuccessful());
@@ -149,304 +144,29 @@ public class GenerateAssertionsAPIMultipleCallsTests {
     assertFalse(response.getBody().retry());
 
     // Request the assertions
-    GetAssertionsRequest getRequest = new GetAssertionsRequest(guideToRaireExample1, 27,
-        Arrays.stream(aliceBobChuanDiego).toList(), DEFAULT_RISK_LIMIT);
-    ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
-        RaireSolution.class);
+    ResponseEntity<RaireSolution> getResponse
+        = restTemplate.postForEntity(getUrl, ByronGetAssertionsRequest, RaireSolution.class);
 
-    // Check for the right metadata
+    // Check for success
     assertTrue(getResponse.getStatusCode().is2xxSuccessful());
     assertNotNull(getResponse.getBody());
-    assertTrue(correctMetadata(Arrays.stream(aliceBobChuanDiego).toList(), guideToRaireExample1,
-        DEFAULT_RISK_LIMIT, 27, getResponse.getBody().metadata, Double.class));
+    int firstAssertionCount = getResponse.getBody().solution.Ok.assertions.length;
 
-    // There should be one NEB assertion: Chaun NEB Bob
-    List<AssertionAndDifficulty> assertions = Arrays.stream(getResponse.getBody().solution.Ok.assertions).toList();
-    Optional<AssertionAndDifficulty> nebMaybeAssertion = assertions.stream()
-        .filter(a -> a.assertion instanceof NotEliminatedBefore).findFirst();
-    assertTrue(nebMaybeAssertion.isPresent());
-    assertTrue(correctAssertionData("NEB", 8, 27/8.0, 2,1, List.of(), 1.0,
-        nebMaybeAssertion.get()));
-  }
+    // Repeat the request
+    restTemplate.postForEntity(generateUrl, ByronNormalTimeoutRequest, GenerateAssertionsResponse.class);
 
-  /**
-   * Exact matching of the assertions described in the Guide to Raire Example 2.
-   * The test data has 1/1000 of the votes, so divide margins by 1000.
-   * The difficulties should be the same, because both numerator and denominator should be divided by 1000.
-   */
-  @Test
-  @Transactional
-  void testGuideToRairePart2Example2() {
-    testUtils.log(logger, "testGuideToRairePart2Example2");
-    String generateUrl = baseURL + port + generateAssertionsEndpoint;
-    String getUrl = baseURL + port + getAssertionsEndpoint;
-    GenerateAssertionsRequest request = new GenerateAssertionsRequest(guideToRaireExample2,
-        41, 5, Arrays.stream(aliceChuanBob).toList());
-
-    // Request for the assertions to be generated.
-    ResponseEntity<GenerateAssertionsResponse> response
-        = restTemplate.postForEntity(generateUrl, request, GenerateAssertionsResponse.class);
-
-    // Check that the response is successful, with no retry.
+    // Check that generation is successful, with no retry.
     assertTrue(response.getStatusCode().is2xxSuccessful());
     assertNotNull(response.getBody());
     assertTrue(response.getBody().succeeded());
     assertFalse(response.getBody().retry());
 
-    // Request the assertions
-    GetAssertionsRequest getRequest = new GetAssertionsRequest(guideToRaireExample2, 41,
-        Arrays.stream(aliceChuanBob).toList(), DEFAULT_RISK_LIMIT);
-    ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
-        RaireSolution.class);
+    // Request the assertions again
+    getResponse = restTemplate.postForEntity(getUrl, ByronGetAssertionsRequest, RaireSolution.class);
 
-    // Check for the right metadata.
+    // Check for success, and that we have the same number of assertions.
     assertTrue(getResponse.getStatusCode().is2xxSuccessful());
     assertNotNull(getResponse.getBody());
-    assertTrue(correctMetadata(Arrays.stream(aliceChuanBob).toList(), guideToRaireExample2,
-        DEFAULT_RISK_LIMIT, 41, getResponse.getBody().metadata, Double.class));
-
-    // Check for the right results: two assertions, margin 9 and difficulty 4.6.
-    RaireResult raireResult = getResponse.getBody().solution.Ok;
-    AssertionAndDifficulty[] assertions = raireResult.assertions;
-    assertEquals(9, raireResult.margin);
-    assertEquals(0, doubleComparator.compare(41.0/9, raireResult.difficulty));
-    checkGuideToRaireExample2Assertions(assertions);
-  }
-
-  /**
-   * Simple contest. The votes are
-   * 2 (A,B)
-   * 2 (B)
-   * 1 (C,A).
-   * The assertions should be
-   * A NEB C
-   * - Margin 1, diluted margin 1/5 = 0.2, difficulty 5/1 = 5.
-   * A NEN B | {A,B} continuing.
-   * - Margin 1, diluted margin 1/5 = 0.2, difficulty 5/1 = 5.
-   * Note that A NEB B is not true.
-   * This is the single-county case.
-   */
-  @Test
-  @Transactional
-  public void simpleContestSingleCounty() {
-    testUtils.log(logger, "simpleContestSingleCounty");
-    String generateUrl = baseURL + port + generateAssertionsEndpoint;
-    String getUrl = baseURL + port + getAssertionsEndpoint;
-
-    GenerateAssertionsRequest request = new GenerateAssertionsRequest(simpleContest,
-        5, 5, Arrays.stream(aliceChuanBob).toList());
-
-    // Request for the assertions to be generated.
-    ResponseEntity<GenerateAssertionsResponse> response
-        = restTemplate.postForEntity(generateUrl, request, GenerateAssertionsResponse.class);
-
-    // Check that the response is successful, with no retry.
-    assertTrue(response.getStatusCode().is2xxSuccessful());
-    assertNotNull(response.getBody());
-    assertTrue(response.getBody().succeeded());
-    assertFalse(response.getBody().retry());
-
-    // Request the assertions
-    GetAssertionsRequest getRequest = new GetAssertionsRequest(simpleContest, 147,
-        Arrays.stream(aliceChuanBob).toList(), DEFAULT_RISK_LIMIT);
-    ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
-        RaireSolution.class);
-
-    // Check for the right metadata.
-    // Note that this metadata - particularly the totalAuditable ballots, but also the candidate
-    // name order - matches the GetAssertionsRequest (not the request for generation).
-    assertTrue(getResponse.getStatusCode().is2xxSuccessful());
-    assertNotNull(getResponse.getBody());
-    assertTrue(correctMetadata(Arrays.stream(aliceChuanBob).toList(), simpleContest,
-        DEFAULT_RISK_LIMIT, 147, getResponse.getBody().metadata, Double.class));
-
-    // Check for the right results: two assertions, margin 9 and difficulty 4.6.
-    RaireResult raireResult = getResponse.getBody().solution.Ok;
-    AssertionAndDifficulty[] assertions = raireResult.assertions;
-    assertEquals(1, raireResult.margin);
-    assertEquals(0, doubleComparator.compare(5.0, raireResult.difficulty));
-    checkSimpleContestAssertions(assertions, 1);
-  }
-
-  /**
-   * The same simple contest, but across two counties. Nothing should change.
-   */
-  @Test
-  @Transactional
-  public void simpleContestCrossCounty() {
-    testUtils.log(logger, "simpleContestCrossCounty");
-    String generateUrl = baseURL + port + generateAssertionsEndpoint;
-    String getUrl = baseURL + port + getAssertionsEndpoint;
-
-    GenerateAssertionsRequest request = new GenerateAssertionsRequest(crossCountySimpleContest,
-        5, 5, Arrays.stream(aliceChuanBob).toList());
-
-    // Request for the assertions to be generated.
-    ResponseEntity<GenerateAssertionsResponse> response
-        = restTemplate.postForEntity(generateUrl, request, GenerateAssertionsResponse.class);
-
-    // Check that the response is successful, with no retry.
-    assertTrue(response.getStatusCode().is2xxSuccessful());
-    assertNotNull(response.getBody());
-    assertTrue(response.getBody().succeeded());
-    assertFalse(response.getBody().retry());
-
-    // Request the assertions
-    GetAssertionsRequest getRequest = new GetAssertionsRequest(crossCountySimpleContest, 5,
-        Arrays.stream(aliceChuanBob).toList(), DEFAULT_RISK_LIMIT);
-    ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
-        RaireSolution.class);
-
-    // Check for the right metadata.
-    assertTrue(getResponse.getStatusCode().is2xxSuccessful());
-    assertNotNull(getResponse.getBody());
-    assertTrue(correctMetadata(Arrays.stream(aliceChuanBob).toList(), crossCountySimpleContest,
-        DEFAULT_RISK_LIMIT, 5, getResponse.getBody().metadata, Double.class));
-
-    // Check for the right results: two assertions, margin 9 and difficulty 4.6.
-    RaireResult raireResult = getResponse.getBody().solution.Ok;
-    AssertionAndDifficulty[] assertions = raireResult.assertions;
-    assertEquals(1, raireResult.margin);
-    assertEquals(0, doubleComparator.compare(5.0, raireResult.difficulty));
-    checkSimpleContestAssertions(assertions, 1);
-  }
-
-  /**
-   * Single-county simple contest again.
-   * Doubling the totalAuditableBallots to 10 doubles the difficulty, and halves the diluted margin,
-   * but does not change the absolute margins.
-   * The actual test data is still the same, with 5 ballots - we just set totalAuditableBallots in
-   * the request to 10.
-   * We now have 10 totalAuditableBallots, so we expect:
-   * A NEB B: Margin 1, diluted margin 1/10 = 0.1, difficulty 10/1 = 10.
-   * A NEN B | {A,B} continuing: Margin 1, diluted margin 1/10 = 0.1, difficulty 10/1 = 10.
-   * Exactly the same as the simpleContest test above, but now we have 10 totalAuditableBallots
-   * and a difficultyFactor=2 in the call to checkSimpleContestAssertions.
-   */
-  @Test
-  @Transactional
-  public void simpleContestSingleCountyDoubleBallots() {
-    testUtils.log(logger, "simpleContestSingleCountyDoubleBallots");
-    String generateUrl = baseURL + port + generateAssertionsEndpoint;
-    String getUrl = baseURL + port + getAssertionsEndpoint;
-
-    // Tell raire that the totalAuditableBallots is double the number in the database
-    // for this contest.
-    GenerateAssertionsRequest request = new GenerateAssertionsRequest(simpleContest,
-         10, 5, Arrays.stream(aliceChuanBob).toList());
-
-    // Request for the assertions to be generated.
-    ResponseEntity<GenerateAssertionsResponse> response
-         = restTemplate.postForEntity(generateUrl, request, GenerateAssertionsResponse.class);
-
-    // Check that the response is successful, with no retry.
-    assertTrue(response.getStatusCode().is2xxSuccessful());
-    assertNotNull(response.getBody());
-    assertTrue(response.getBody().succeeded());
-    assertFalse(response.getBody().retry());
-
-     // Request the assertions
-     GetAssertionsRequest getRequest = new GetAssertionsRequest(simpleContest, 10,
-         Arrays.stream(aliceChuanBob).toList(), DEFAULT_RISK_LIMIT);
-     ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
-         RaireSolution.class);
-
-     // Check for the right metadata.
-     assertTrue(getResponse.getStatusCode().is2xxSuccessful());
-     assertNotNull(getResponse.getBody());
-     assertTrue(correctMetadata(Arrays.stream(aliceChuanBob).toList(), simpleContest,
-         DEFAULT_RISK_LIMIT, 10, getResponse.getBody().metadata, Double.class));
-
-     // Check for the right results: two assertions, margin 9 and difficulty 4.6.
-     RaireResult raireResult = getResponse.getBody().solution.Ok;
-     AssertionAndDifficulty[] assertions = raireResult.assertions;
-     assertEquals(1, raireResult.margin);
-     assertEquals(0, doubleComparator.compare(10.0, raireResult.difficulty));
-
-     // Difficulty factor 2 to match the doubled totalAuditableBallots.
-     checkSimpleContestAssertions(assertions, 2);
-  }
-
-  /**
-   * Insufficient totalAuditableBallots causes the right raire error to be returned.
-   * This test case has 5 ballots, so 2 totalAuditableBallots is an error.
-   */
-  @Test
-  @Transactional
-  public void simpleContestSingleCountyInsufficientBallotsError() {
-    testUtils.log(logger, "simpleContestSingleCountyInsufficientBallotsError");
-    String generateUrl = baseURL + port + generateAssertionsEndpoint;
-
-    GenerateAssertionsRequest notEnoughBallotsRequest = new GenerateAssertionsRequest(simpleContest,
-        2, 5, Arrays.stream(aliceChuanBob).toList());
-
-    // Request for the assertions to be generated.
-    ResponseEntity<String> response
-        = restTemplate.postForEntity(generateUrl, notEnoughBallotsRequest, String.class);
-
-    assertTrue(response.getStatusCode().is5xxServerError());
-    assertEquals(RaireErrorCode.INVALID_TOTAL_AUDITABLE_BALLOTS.toString(),
-        response.getHeaders().getFirst(ERROR_CODE_KEY));
-  }
-
-  /**
-    * Check the data for the simple contests. Note that the winner and loser indices
-    * are dependent on the order of the input candidate list, which in all the test
-    * that use it are Alice, Chuan, Bob.
-    * @param assertionAndDifficulties the assertions returned by API
-    * @param difficultyFactor factor by which the difficulty should be multiplied (because of larger
-    *                         universe size).
-    */
-  private void checkSimpleContestAssertions(AssertionAndDifficulty[] assertionAndDifficulties,
-      double difficultyFactor) {
-    assertEquals(2, assertionAndDifficulties.length);
-    int nebIndex;
-
-    if(assertionAndDifficulties[0].assertion instanceof NotEliminatedBefore) {
-      nebIndex = 0;
-    } else {
-      nebIndex = 1;
-    }
-
-    // There should be one NEB assertion: Alice NEB Chuan
-    // Margin 1, diluted margin 0.2, difficulty 5.
-    assertTrue(correctAssertionData("NEB", 1, 5*difficultyFactor,
-        0,1, List.of(), 1.0, assertionAndDifficulties[nebIndex]));
-
-    // There should be one NEN assertion: Chuan > Bob if only {Chuan,Bob} remain.
-    // Margin is 9,000, but data is divided by 1000, so 9. Difficulty is 41/9 = 4.5555...,
-    // rounded to 4.6 in the Guide.
-    // Diluted margin is 9/41 = 0.219512195...
-    assertTrue(correctAssertionData("NEN", 1, 5*difficultyFactor,
-        0, 2, List.of(0,2), 1.0, assertionAndDifficulties[1-nebIndex]));
-  }
-
-  /**
-   * Checks for exact match with the Guide To Raire Part 2, example 2.
-   * Same as GenerateAssertionsServiceKnownTests::checkGuideToRaireExample2Assertions, except that
-   * it inputs an array of raire-java::AssertionAndDifficulty.
-   */
-  private void checkGuideToRaireExample2Assertions(AssertionAndDifficulty @NotNull [] assertionAndDifficulties) {
-    assertEquals(2, assertionAndDifficulties.length);
-    int nebIndex;
-
-    if(assertionAndDifficulties[0].assertion instanceof NotEliminatedBefore) {
-      nebIndex = 0;
-    } else {
-      nebIndex = 1;
-    }
-
-    // There should be one NEB assertion: Chaun NEB Alice
-    // Margin is 10,000, but data is divided by 1000, so 10. Difficulty is 4.1 as in the Guide.
-    // Diluted Margin is 10/41.
-    assertTrue(correctAssertionData("NEB", 10, 4.1,
-        1,0, List.of(), 1.0, assertionAndDifficulties[nebIndex]));
-
-    // There should be one NEN assertion: Chuan > Bob if only {Chuan,Bob} remain.
-    // Margin is 9,000, but data is divided by 1000, so 9. Difficulty is 41/9 = 4.5555...,
-    // rounded to 4.6 in the Guide.
-    // Diluted margin is 9/41 = 0.219512195...
-    assertTrue(correctAssertionData("NEN", 9, 41.0/9,
-        1, 2, List.of(1,2), 1.0, assertionAndDifficulties[1-nebIndex]));
+    assertEquals(firstAssertionCount, getResponse.getBody().solution.Ok.assertions.length);
   }
 }

--- a/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIMultipleCallsTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIMultipleCallsTests.java
@@ -1,0 +1,452 @@
+/*
+Copyright 2024 Democracy Developers
+
+The Raire Service is designed to connect colorado-rla and its associated database to
+the raire assertion generation engine (https://github.com/DemocracyDevelopers/raire-java).
+
+This file is part of raire-service.
+
+raire-service is free software: you can redistribute it and/or modify it under the terms
+of the GNU Affero General Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+raire-service is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with
+raire-service. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package au.org.democracydevelopers.raireservice.controller;
+
+import au.org.democracydevelopers.raire.RaireSolution;
+import au.org.democracydevelopers.raire.algorithm.RaireResult;
+import au.org.democracydevelopers.raire.assertions.AssertionAndDifficulty;
+import au.org.democracydevelopers.raire.assertions.NotEliminatedBefore;
+import au.org.democracydevelopers.raireservice.request.GenerateAssertionsRequest;
+import au.org.democracydevelopers.raireservice.request.GetAssertionsRequest;
+import au.org.democracydevelopers.raireservice.response.GenerateAssertionsResponse;
+import au.org.democracydevelopers.raireservice.service.RaireServiceException.RaireErrorCode;
+import au.org.democracydevelopers.raireservice.testUtils;
+import au.org.democracydevelopers.raireservice.util.DoubleComparator;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static au.org.democracydevelopers.raireservice.service.RaireServiceException.ERROR_CODE_KEY;
+import static au.org.democracydevelopers.raireservice.testUtils.correctAssertionData;
+import static au.org.democracydevelopers.raireservice.testUtils.correctMetadata;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests to validate the behaviour of the Assertion generation API when called successively.
+ * Relevant data is preloaded into the test database from
+ * src/test/resources/known_testcases_votes.sql.
+ * These tests include
+ * 1. Calling the endpoint twice with no parameters. The state at the end of the second call should be
+ *   the same as at the end of the first.
+ * 2. Calling the endpoint first with an extremely small time limit that causes assertion generation
+ *   to fail, then calling it again with a longer time limit that succeeds. This should store
+ *   assertions and replace the summary.
+ * 3. Calling the endpoint first with a tied contest, then again with altered CVRs that don't tie.
+ *   This should store assertions and replace the summary.
+ * 4. The same as (2), but in the opposite order.
+ * 5. The same as (3), but in the opposite order.
+ * In each case, the test
+ * - makes a request for assertion generation through the API,
+ * - checks for the right winner,
+ * - requests the assertion data through the get-assertions API (JSON),
+ * TODO - better get the summaries somehow - dashboard? - or should we be reading the DB to see what's there?
+ * - verifies the expected difficulty,
+ * and checks for the expected data.
+ */
+@ActiveProfiles("known-testcases")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+public class GenerateAssertionsAPIMultipleCallsTests {
+
+  private static final Logger logger = LoggerFactory.getLogger(GenerateAssertionsAPIMultipleCallsTests.class);
+  private final static String baseURL = "http://localhost:";
+  private final static String generateAssertionsEndpoint = "/raire/generate-assertions";
+
+  // Get assertions endpoint - used for testing that they were generated properly.
+  private final static String getAssertionsEndpoint = "/raire/get-assertions-json";
+  private static final int DEFAULT_TIME_LIMIT = 5;
+  private static final BigDecimal DEFAULT_RISK_LIMIT = BigDecimal.valueOf(0.03);
+  private static final DoubleComparator doubleComparator = new DoubleComparator();
+
+  @LocalServerPort
+  private int port;
+
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  /**
+   * Names of contests, to match preloaded data.
+   */
+  private static final String guideToRaireExample1 = "Guide To Raire Example 1";
+  private static final String guideToRaireExample2 = "Guide To Raire Example 2";
+  private static final String simpleContest = "Simple Contest";
+  private static final String crossCountySimpleContest = "Cross-county Simple Contest";
+
+  /**
+   * Array of candidates: Alice, Bob, Chuan, Diego.
+   */
+  private static final String[] aliceBobChuanDiego = {"Alice", "Bob", "Chuan", "Diego"};
+
+  /**
+   * Array of candidates: Alice, Chuan, Bob.
+   */
+  private static final String[] aliceChuanBob = {"Alice", "Chuan", "Bob"};
+
+  /**
+   * Test the first example in the Guide to Raire Part 2.
+   * The test data has 1/500 of the votes, so divide margins by 500.
+   * The difficulties should be the same, because both numerator and denominator should be divided by 500.
+   * We do not test the NEN assertions because the ones in the Guide have some redundancy.
+   * Test assertion: Chuan NEB Bob.
+   * Margin is 4000, but data is divided by 500, so 8. Difficulty is 3.375 as in the Guide.
+   * Diluted margin is 8/27 = 0.296...
+   */
+  @Test
+  @Transactional
+  public void testGuideToRairePart2Example1() {
+    testUtils.log(logger, "testGuideToRairePart2Example1");
+    String generateUrl = baseURL + port + generateAssertionsEndpoint;
+    String getUrl = baseURL + port + getAssertionsEndpoint;
+
+    GenerateAssertionsRequest request = new GenerateAssertionsRequest(guideToRaireExample1,
+        27, DEFAULT_TIME_LIMIT, Arrays.stream(aliceBobChuanDiego).toList());
+
+
+    // Request for the assertions to be generated.
+    ResponseEntity<GenerateAssertionsResponse> response = restTemplate.postForEntity(generateUrl,
+        request, GenerateAssertionsResponse.class);
+
+    // Check that generation is successful, with no retry.
+    assertTrue(response.getStatusCode().is2xxSuccessful());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().succeeded());
+    assertFalse(response.getBody().retry());
+
+    // Request the assertions
+    GetAssertionsRequest getRequest = new GetAssertionsRequest(guideToRaireExample1, 27,
+        Arrays.stream(aliceBobChuanDiego).toList(), DEFAULT_RISK_LIMIT);
+    ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
+        RaireSolution.class);
+
+    // Check for the right metadata
+    assertTrue(getResponse.getStatusCode().is2xxSuccessful());
+    assertNotNull(getResponse.getBody());
+    assertTrue(correctMetadata(Arrays.stream(aliceBobChuanDiego).toList(), guideToRaireExample1,
+        DEFAULT_RISK_LIMIT, 27, getResponse.getBody().metadata, Double.class));
+
+    // There should be one NEB assertion: Chaun NEB Bob
+    List<AssertionAndDifficulty> assertions = Arrays.stream(getResponse.getBody().solution.Ok.assertions).toList();
+    Optional<AssertionAndDifficulty> nebMaybeAssertion = assertions.stream()
+        .filter(a -> a.assertion instanceof NotEliminatedBefore).findFirst();
+    assertTrue(nebMaybeAssertion.isPresent());
+    assertTrue(correctAssertionData("NEB", 8, 27/8.0, 2,1, List.of(), 1.0,
+        nebMaybeAssertion.get()));
+  }
+
+  /**
+   * Exact matching of the assertions described in the Guide to Raire Example 2.
+   * The test data has 1/1000 of the votes, so divide margins by 1000.
+   * The difficulties should be the same, because both numerator and denominator should be divided by 1000.
+   */
+  @Test
+  @Transactional
+  void testGuideToRairePart2Example2() {
+    testUtils.log(logger, "testGuideToRairePart2Example2");
+    String generateUrl = baseURL + port + generateAssertionsEndpoint;
+    String getUrl = baseURL + port + getAssertionsEndpoint;
+    GenerateAssertionsRequest request = new GenerateAssertionsRequest(guideToRaireExample2,
+        41, 5, Arrays.stream(aliceChuanBob).toList());
+
+    // Request for the assertions to be generated.
+    ResponseEntity<GenerateAssertionsResponse> response
+        = restTemplate.postForEntity(generateUrl, request, GenerateAssertionsResponse.class);
+
+    // Check that the response is successful, with no retry.
+    assertTrue(response.getStatusCode().is2xxSuccessful());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().succeeded());
+    assertFalse(response.getBody().retry());
+
+    // Request the assertions
+    GetAssertionsRequest getRequest = new GetAssertionsRequest(guideToRaireExample2, 41,
+        Arrays.stream(aliceChuanBob).toList(), DEFAULT_RISK_LIMIT);
+    ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
+        RaireSolution.class);
+
+    // Check for the right metadata.
+    assertTrue(getResponse.getStatusCode().is2xxSuccessful());
+    assertNotNull(getResponse.getBody());
+    assertTrue(correctMetadata(Arrays.stream(aliceChuanBob).toList(), guideToRaireExample2,
+        DEFAULT_RISK_LIMIT, 41, getResponse.getBody().metadata, Double.class));
+
+    // Check for the right results: two assertions, margin 9 and difficulty 4.6.
+    RaireResult raireResult = getResponse.getBody().solution.Ok;
+    AssertionAndDifficulty[] assertions = raireResult.assertions;
+    assertEquals(9, raireResult.margin);
+    assertEquals(0, doubleComparator.compare(41.0/9, raireResult.difficulty));
+    checkGuideToRaireExample2Assertions(assertions);
+  }
+
+  /**
+   * Simple contest. The votes are
+   * 2 (A,B)
+   * 2 (B)
+   * 1 (C,A).
+   * The assertions should be
+   * A NEB C
+   * - Margin 1, diluted margin 1/5 = 0.2, difficulty 5/1 = 5.
+   * A NEN B | {A,B} continuing.
+   * - Margin 1, diluted margin 1/5 = 0.2, difficulty 5/1 = 5.
+   * Note that A NEB B is not true.
+   * This is the single-county case.
+   */
+  @Test
+  @Transactional
+  public void simpleContestSingleCounty() {
+    testUtils.log(logger, "simpleContestSingleCounty");
+    String generateUrl = baseURL + port + generateAssertionsEndpoint;
+    String getUrl = baseURL + port + getAssertionsEndpoint;
+
+    GenerateAssertionsRequest request = new GenerateAssertionsRequest(simpleContest,
+        5, 5, Arrays.stream(aliceChuanBob).toList());
+
+    // Request for the assertions to be generated.
+    ResponseEntity<GenerateAssertionsResponse> response
+        = restTemplate.postForEntity(generateUrl, request, GenerateAssertionsResponse.class);
+
+    // Check that the response is successful, with no retry.
+    assertTrue(response.getStatusCode().is2xxSuccessful());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().succeeded());
+    assertFalse(response.getBody().retry());
+
+    // Request the assertions
+    GetAssertionsRequest getRequest = new GetAssertionsRequest(simpleContest, 147,
+        Arrays.stream(aliceChuanBob).toList(), DEFAULT_RISK_LIMIT);
+    ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
+        RaireSolution.class);
+
+    // Check for the right metadata.
+    // Note that this metadata - particularly the totalAuditable ballots, but also the candidate
+    // name order - matches the GetAssertionsRequest (not the request for generation).
+    assertTrue(getResponse.getStatusCode().is2xxSuccessful());
+    assertNotNull(getResponse.getBody());
+    assertTrue(correctMetadata(Arrays.stream(aliceChuanBob).toList(), simpleContest,
+        DEFAULT_RISK_LIMIT, 147, getResponse.getBody().metadata, Double.class));
+
+    // Check for the right results: two assertions, margin 9 and difficulty 4.6.
+    RaireResult raireResult = getResponse.getBody().solution.Ok;
+    AssertionAndDifficulty[] assertions = raireResult.assertions;
+    assertEquals(1, raireResult.margin);
+    assertEquals(0, doubleComparator.compare(5.0, raireResult.difficulty));
+    checkSimpleContestAssertions(assertions, 1);
+  }
+
+  /**
+   * The same simple contest, but across two counties. Nothing should change.
+   */
+  @Test
+  @Transactional
+  public void simpleContestCrossCounty() {
+    testUtils.log(logger, "simpleContestCrossCounty");
+    String generateUrl = baseURL + port + generateAssertionsEndpoint;
+    String getUrl = baseURL + port + getAssertionsEndpoint;
+
+    GenerateAssertionsRequest request = new GenerateAssertionsRequest(crossCountySimpleContest,
+        5, 5, Arrays.stream(aliceChuanBob).toList());
+
+    // Request for the assertions to be generated.
+    ResponseEntity<GenerateAssertionsResponse> response
+        = restTemplate.postForEntity(generateUrl, request, GenerateAssertionsResponse.class);
+
+    // Check that the response is successful, with no retry.
+    assertTrue(response.getStatusCode().is2xxSuccessful());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().succeeded());
+    assertFalse(response.getBody().retry());
+
+    // Request the assertions
+    GetAssertionsRequest getRequest = new GetAssertionsRequest(crossCountySimpleContest, 5,
+        Arrays.stream(aliceChuanBob).toList(), DEFAULT_RISK_LIMIT);
+    ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
+        RaireSolution.class);
+
+    // Check for the right metadata.
+    assertTrue(getResponse.getStatusCode().is2xxSuccessful());
+    assertNotNull(getResponse.getBody());
+    assertTrue(correctMetadata(Arrays.stream(aliceChuanBob).toList(), crossCountySimpleContest,
+        DEFAULT_RISK_LIMIT, 5, getResponse.getBody().metadata, Double.class));
+
+    // Check for the right results: two assertions, margin 9 and difficulty 4.6.
+    RaireResult raireResult = getResponse.getBody().solution.Ok;
+    AssertionAndDifficulty[] assertions = raireResult.assertions;
+    assertEquals(1, raireResult.margin);
+    assertEquals(0, doubleComparator.compare(5.0, raireResult.difficulty));
+    checkSimpleContestAssertions(assertions, 1);
+  }
+
+  /**
+   * Single-county simple contest again.
+   * Doubling the totalAuditableBallots to 10 doubles the difficulty, and halves the diluted margin,
+   * but does not change the absolute margins.
+   * The actual test data is still the same, with 5 ballots - we just set totalAuditableBallots in
+   * the request to 10.
+   * We now have 10 totalAuditableBallots, so we expect:
+   * A NEB B: Margin 1, diluted margin 1/10 = 0.1, difficulty 10/1 = 10.
+   * A NEN B | {A,B} continuing: Margin 1, diluted margin 1/10 = 0.1, difficulty 10/1 = 10.
+   * Exactly the same as the simpleContest test above, but now we have 10 totalAuditableBallots
+   * and a difficultyFactor=2 in the call to checkSimpleContestAssertions.
+   */
+  @Test
+  @Transactional
+  public void simpleContestSingleCountyDoubleBallots() {
+    testUtils.log(logger, "simpleContestSingleCountyDoubleBallots");
+    String generateUrl = baseURL + port + generateAssertionsEndpoint;
+    String getUrl = baseURL + port + getAssertionsEndpoint;
+
+    // Tell raire that the totalAuditableBallots is double the number in the database
+    // for this contest.
+    GenerateAssertionsRequest request = new GenerateAssertionsRequest(simpleContest,
+         10, 5, Arrays.stream(aliceChuanBob).toList());
+
+    // Request for the assertions to be generated.
+    ResponseEntity<GenerateAssertionsResponse> response
+         = restTemplate.postForEntity(generateUrl, request, GenerateAssertionsResponse.class);
+
+    // Check that the response is successful, with no retry.
+    assertTrue(response.getStatusCode().is2xxSuccessful());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().succeeded());
+    assertFalse(response.getBody().retry());
+
+     // Request the assertions
+     GetAssertionsRequest getRequest = new GetAssertionsRequest(simpleContest, 10,
+         Arrays.stream(aliceChuanBob).toList(), DEFAULT_RISK_LIMIT);
+     ResponseEntity<RaireSolution> getResponse = restTemplate.postForEntity(getUrl, getRequest,
+         RaireSolution.class);
+
+     // Check for the right metadata.
+     assertTrue(getResponse.getStatusCode().is2xxSuccessful());
+     assertNotNull(getResponse.getBody());
+     assertTrue(correctMetadata(Arrays.stream(aliceChuanBob).toList(), simpleContest,
+         DEFAULT_RISK_LIMIT, 10, getResponse.getBody().metadata, Double.class));
+
+     // Check for the right results: two assertions, margin 9 and difficulty 4.6.
+     RaireResult raireResult = getResponse.getBody().solution.Ok;
+     AssertionAndDifficulty[] assertions = raireResult.assertions;
+     assertEquals(1, raireResult.margin);
+     assertEquals(0, doubleComparator.compare(10.0, raireResult.difficulty));
+
+     // Difficulty factor 2 to match the doubled totalAuditableBallots.
+     checkSimpleContestAssertions(assertions, 2);
+  }
+
+  /**
+   * Insufficient totalAuditableBallots causes the right raire error to be returned.
+   * This test case has 5 ballots, so 2 totalAuditableBallots is an error.
+   */
+  @Test
+  @Transactional
+  public void simpleContestSingleCountyInsufficientBallotsError() {
+    testUtils.log(logger, "simpleContestSingleCountyInsufficientBallotsError");
+    String generateUrl = baseURL + port + generateAssertionsEndpoint;
+
+    GenerateAssertionsRequest notEnoughBallotsRequest = new GenerateAssertionsRequest(simpleContest,
+        2, 5, Arrays.stream(aliceChuanBob).toList());
+
+    // Request for the assertions to be generated.
+    ResponseEntity<String> response
+        = restTemplate.postForEntity(generateUrl, notEnoughBallotsRequest, String.class);
+
+    assertTrue(response.getStatusCode().is5xxServerError());
+    assertEquals(RaireErrorCode.INVALID_TOTAL_AUDITABLE_BALLOTS.toString(),
+        response.getHeaders().getFirst(ERROR_CODE_KEY));
+  }
+
+  /**
+    * Check the data for the simple contests. Note that the winner and loser indices
+    * are dependent on the order of the input candidate list, which in all the test
+    * that use it are Alice, Chuan, Bob.
+    * @param assertionAndDifficulties the assertions returned by API
+    * @param difficultyFactor factor by which the difficulty should be multiplied (because of larger
+    *                         universe size).
+    */
+  private void checkSimpleContestAssertions(AssertionAndDifficulty[] assertionAndDifficulties,
+      double difficultyFactor) {
+    assertEquals(2, assertionAndDifficulties.length);
+    int nebIndex;
+
+    if(assertionAndDifficulties[0].assertion instanceof NotEliminatedBefore) {
+      nebIndex = 0;
+    } else {
+      nebIndex = 1;
+    }
+
+    // There should be one NEB assertion: Alice NEB Chuan
+    // Margin 1, diluted margin 0.2, difficulty 5.
+    assertTrue(correctAssertionData("NEB", 1, 5*difficultyFactor,
+        0,1, List.of(), 1.0, assertionAndDifficulties[nebIndex]));
+
+    // There should be one NEN assertion: Chuan > Bob if only {Chuan,Bob} remain.
+    // Margin is 9,000, but data is divided by 1000, so 9. Difficulty is 41/9 = 4.5555...,
+    // rounded to 4.6 in the Guide.
+    // Diluted margin is 9/41 = 0.219512195...
+    assertTrue(correctAssertionData("NEN", 1, 5*difficultyFactor,
+        0, 2, List.of(0,2), 1.0, assertionAndDifficulties[1-nebIndex]));
+  }
+
+  /**
+   * Checks for exact match with the Guide To Raire Part 2, example 2.
+   * Same as GenerateAssertionsServiceKnownTests::checkGuideToRaireExample2Assertions, except that
+   * it inputs an array of raire-java::AssertionAndDifficulty.
+   */
+  private void checkGuideToRaireExample2Assertions(AssertionAndDifficulty @NotNull [] assertionAndDifficulties) {
+    assertEquals(2, assertionAndDifficulties.length);
+    int nebIndex;
+
+    if(assertionAndDifficulties[0].assertion instanceof NotEliminatedBefore) {
+      nebIndex = 0;
+    } else {
+      nebIndex = 1;
+    }
+
+    // There should be one NEB assertion: Chaun NEB Alice
+    // Margin is 10,000, but data is divided by 1000, so 10. Difficulty is 4.1 as in the Guide.
+    // Diluted Margin is 10/41.
+    assertTrue(correctAssertionData("NEB", 10, 4.1,
+        1,0, List.of(), 1.0, assertionAndDifficulties[nebIndex]));
+
+    // There should be one NEN assertion: Chuan > Bob if only {Chuan,Bob} remain.
+    // Margin is 9,000, but data is divided by 1000, so 9. Difficulty is 41/9 = 4.5555...,
+    // rounded to 4.6 in the Guide.
+    // Diluted margin is 9/41 = 0.219512195...
+    assertTrue(correctAssertionData("NEN", 9, 41.0/9,
+        1, 2, List.of(1,2), 1.0, assertionAndDifficulties[1-nebIndex]));
+  }
+}

--- a/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIWickedTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIWickedTests.java
@@ -68,7 +68,7 @@ public class GenerateAssertionsAPIWickedTests {
    * Names of contests, to match preloaded data.
    */
   private static final String tiedWinnersContest = "Tied Winners Contest";
-  private static final String ByronMayoral = "Byron Mayoral";
+  protected static final String ByronMayoral = "Byron Mayoral";
   private static final String timeOutCheckingWinnersContest = "Time out checking winners contest";
 
   /**

--- a/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIWickedTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIWickedTests.java
@@ -89,7 +89,7 @@ public class GenerateAssertionsAPIWickedTests {
   private final static GenerateAssertionsRequest tiedWinnersRequest
       = new GenerateAssertionsRequest(tiedWinnersContest, 2, 5,
       aliceChuanBob);
-  private final static GenerateAssertionsRequest ByronShortTimeoutRequest
+  protected final static GenerateAssertionsRequest ByronShortTimeoutRequest
       = new GenerateAssertionsRequest(ByronMayoral, 18165, 0.001,
       choicesByron);
   private final static GenerateAssertionsRequest checkingWinnersTimeoutRequest

--- a/src/test/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsServiceKnownTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsServiceKnownTests.java
@@ -100,7 +100,7 @@ public class GenerateAssertionsServiceKnownTests {
   private static final String oneNENAssertionContest = "Sanity Check NEN Assertion Contest";
   private static final String NEBNENAssertionContest = "Sanity Check NEB NEN Assertion Contest";
   private static final String ThreeAssertionContest = "Sanity Check 3 Assertion Contest";
-  private static final String guideToRaireExample1 = "Guide To Raire Example 1";
+  protected static final String guideToRaireExample1 = "Guide To Raire Example 1";
   private static final String guideToRaireExample2 = "Guide To Raire Example 2";
   private static final String simpleContest = "Simple Contest";
   private static final String crossCountySimpleContest = "Cross-county Simple Contest";
@@ -108,7 +108,7 @@ public class GenerateAssertionsServiceKnownTests {
   /**
    * Array of candidates: Alice, Bob, Chuan, Diego.
    */
-  private static final String[] aliceBobChuanDiego = {"Alice", "Bob", "Chuan", "Diego"};
+  protected static final String[] aliceBobChuanDiego = {"Alice", "Bob", "Chuan", "Diego"};
 
   /**
    * Array of candidates: Alice, Chuan, Bob.
@@ -380,7 +380,7 @@ public class GenerateAssertionsServiceKnownTests {
     RaireServiceException ex = assertThrows(RaireServiceException.class, () ->
         generateAssertionsService.generateAssertions(notEnoughBallotsRequest)
     );
-    assertSame(ex.errorCode, RaireErrorCode.INVALID_TOTAL_AUDITABLE_BALLOTS);
+    assertSame(RaireErrorCode.INVALID_TOTAL_AUDITABLE_BALLOTS, ex.errorCode);
 
     // Check there is no summary data.
     Optional<GenerateAssertionsSummary> optSummary
@@ -404,7 +404,7 @@ public class GenerateAssertionsServiceKnownTests {
     RaireServiceException ex = assertThrows(RaireServiceException.class, () ->
         generateAssertionsService.generateAssertions(wrongCandidatesRequest)
     );
-    assertSame(ex.errorCode, RaireErrorCode.WRONG_CANDIDATE_NAMES);
+    assertSame(RaireErrorCode.WRONG_CANDIDATE_NAMES, ex.errorCode);
 
     // Check there is no summary data.
     Optional<GenerateAssertionsSummary> optSummary

--- a/src/test/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsServiceMultipleCallsTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsServiceMultipleCallsTests.java
@@ -1,0 +1,237 @@
+/*
+Copyright 2024 Democracy Developers
+
+The Raire Service is designed to connect colorado-rla and its associated database to
+the raire assertion generation engine (https://github.com/DemocracyDevelopers/raire-java).
+
+This file is part of raire-service.
+
+raire-service is free software: you can redistribute it and/or modify it under the terms
+of the GNU Affero General Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+raire-service is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with
+raire-service. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package au.org.democracydevelopers.raireservice.service;
+
+
+import au.org.democracydevelopers.raire.RaireError;
+import au.org.democracydevelopers.raire.RaireSolution.RaireResultOrError;
+import au.org.democracydevelopers.raire.algorithm.RaireResult;
+import au.org.democracydevelopers.raireservice.persistence.entity.Assertion;
+import au.org.democracydevelopers.raireservice.persistence.entity.GenerateAssertionsSummary;
+import au.org.democracydevelopers.raireservice.persistence.repository.AssertionRepository;
+import au.org.democracydevelopers.raireservice.persistence.repository.GenerateAssertionsSummaryRepository;
+import au.org.democracydevelopers.raireservice.request.GenerateAssertionsRequest;
+import au.org.democracydevelopers.raireservice.testUtils;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static au.org.democracydevelopers.raireservice.NSWValues.winnerContest_12;
+import static au.org.democracydevelopers.raireservice.service.GenerateAssertionsServiceWickedTests.*;
+import static au.org.democracydevelopers.raireservice.service.RaireServiceException.RaireErrorCode.TIMEOUT_FINDING_ASSERTIONS;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests to validate the behaviour of Assertion generation when called successively.
+ * Relevant data is preloaded into the test database from
+ * src/test/resources/known_testcases_votes.sql.
+ * These tests include
+ * 1. Calling the endpoint twice with the same contest name. The state at the end of the second call
+ * should be the same as at the end of the first.
+ * 2. Calling the endpoint first with an extremely small time limit that causes assertion generation
+ * to fail, then calling it again with a longer time limit that succeeds. This should store
+ * assertions and replace the summary.
+ * 3. The same as (2), but in the opposite order.
+ * In each case, the test
+ * - makes a request for assertion generation in the service,
+ * - checks for the right state (OK or error),
+ * - checks for the right generateAssertionsSummary,
+ * - checks whether the assertion list is empty.
+ */
+@ActiveProfiles("known-testcases")
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+public class GenerateAssertionsServiceMultipleCallsTests {
+
+  private static final Logger logger = LoggerFactory.getLogger(GenerateAssertionsServiceMultipleCallsTests.class);
+
+  @Autowired
+  AssertionRepository assertionRepository;
+
+  @Autowired
+  GenerateAssertionsSummaryRepository summaryRepository;
+
+  @Autowired
+  GenerateAssertionsService generateAssertionsService;
+
+  /**
+   * Second request for Byron, with a normal time limit.
+   */
+  final static GenerateAssertionsRequest ByronNormalTimeoutRequest
+      = new GenerateAssertionsRequest(ByronMayoral, 18165, 5,
+      choicesByron);
+
+  /**
+   * Run assertion generation on Byron Mayoral twice with the default timeout. Verify that the
+   * results are the same both times.
+   * This test doesn't do exhaustive search of the data - it just sanity-checks that the
+   * assertion generation summaries are the same, and the assertion lists are the same size.
+   */
+  @Test
+  @Transactional
+  void ByronRunsTwiceSameResults() throws RaireServiceException {
+    {
+      testUtils.log(logger, "ByronRunsTwiceSameResults");
+
+      // Make the request with a very short timeout - expected to fail.
+      RaireResultOrError result = generateAssertionsService.generateAssertions(ByronNormalTimeoutRequest);
+
+      assertNotNull(result.Ok);
+      assertNull(result.Err);
+
+      assertInstanceOf(RaireResult.class, result.Ok);
+      int resultLength = result.Ok.assertions.length;
+
+      generateAssertionsService.persistAssertionsOrErrors(result, ByronNormalTimeoutRequest);
+      Optional<GenerateAssertionsSummary> optSummary = summaryRepository.findByContestName(ByronMayoral);
+      assertTrue(optSummary.isPresent());
+      GenerateAssertionsSummary firstSummary = optSummary.get();
+
+      // Check there are assertions in the database, of the same size as the result.
+      List<Assertion> assertions = assertionRepository.findByContestName(ByronMayoral);
+      assertEquals(resultLength, assertions.size());
+
+      // Make a second identical request - expected to succeed.
+      result = generateAssertionsService.generateAssertions(ByronNormalTimeoutRequest);
+
+      assertNotNull(result.Ok);
+      assertNull(result.Err);
+
+      // Check the assertions have the same length as they did in the first request.
+      assertInstanceOf(RaireResult.class, result.Ok);
+      assertEquals(resultLength, result.Ok.assertions.length);
+
+      generateAssertionsService.persistAssertionsOrErrors(result, ByronNormalTimeoutRequest);
+      optSummary = summaryRepository.findByContestName(ByronMayoral);
+      assertTrue(optSummary.isPresent());
+      assertTrue(optSummary.get().equalData(ByronMayoral, firstSummary.getWinner(),
+          firstSummary.getError(), firstSummary.getWarning(), firstSummary.getMessage()));
+
+      // Check there are the same number of assertions in the database.
+      assertions = assertionRepository.findByContestName(ByronMayoral);
+      assertEquals(resultLength, assertions.size());
+    }
+  }
+
+  /**
+   * Run assertion generation on Byron Mayoral, first with a too-short timeout, then again with a
+   * workable timeout. Verify that the error state is stored first, then replaced with success.
+   * This test doesn't do exhaustive search of the data - it just sanity-checks that first the
+   * failure result with no assertions, then the success result with some assertions, are stored.
+   */
+  @Test
+  @Transactional
+  void ByronTimeoutsSuccessReplacesFailure() throws RaireServiceException {
+    testUtils.log(logger, "ByronTimeoutsSuccessReplacesFailure");
+
+    // Make the request with a very short timeout - expected to fail.
+    RaireResultOrError result = generateAssertionsService.generateAssertions(ByronShortTimeoutRequest);
+
+    assertNull(result.Ok);
+    assertNotNull(result.Err);
+
+    assertInstanceOf(RaireError.TimeoutFindingAssertions.class, result.Err);
+
+    generateAssertionsService.persistAssertionsOrErrors(result, ByronShortTimeoutRequest);
+    Optional<GenerateAssertionsSummary> optSummary = summaryRepository.findByContestName(ByronMayoral);
+    assertTrue(optSummary.isPresent());
+    assertTrue(optSummary.get().equalData(ByronMayoral, "",
+        TIMEOUT_FINDING_ASSERTIONS.toString(), "", "Time out finding assertions"));
+
+    // Check there are no assertions in the database.
+    List<Assertion> assertions = assertionRepository.findByContestName(ByronMayoral);
+    assertEquals(0, assertions.size());
+
+    // Make the request with a normal timeout - expected to succeed. Check that the successful
+    // values replace those from the failure.
+    result = generateAssertionsService.generateAssertions(ByronNormalTimeoutRequest);
+
+    assertNotNull(result.Ok);
+    assertNull(result.Err);
+
+    generateAssertionsService.persistAssertionsOrErrors(result, ByronNormalTimeoutRequest);
+    optSummary = summaryRepository.findByContestName(ByronMayoral);
+    assertTrue(optSummary.isPresent());
+    assertTrue(optSummary.get().equalData(ByronMayoral, winnerContest_12, "", "", ""));
+
+    // Check there are some assertions in the database.
+    assertions = assertionRepository.findByContestName(ByronMayoral);
+    assertFalse(assertions.isEmpty());
+
+  }
+
+  /**
+   * The same as ByronTimeoutsSuccessReplacesFailure, but in the opposite order.
+   * @throws RaireServiceException if something goes wrong with database storage.
+   */
+  @Test
+  @Transactional
+  void ByronTimeoutsFailureReplacesSuccess() throws RaireServiceException {
+    testUtils.log(logger, "ByronTimeoutsFailureReplacesSuccess");
+
+    // Make the request with a normal timeout - expected to succeed. Check that the successful
+    // values replace those from the failure.
+    RaireResultOrError result = generateAssertionsService.generateAssertions(ByronNormalTimeoutRequest);
+
+    assertNotNull(result.Ok);
+    assertNull(result.Err);
+
+    generateAssertionsService.persistAssertionsOrErrors(result, ByronNormalTimeoutRequest);
+    Optional<GenerateAssertionsSummary> optSummary = summaryRepository.findByContestName(ByronMayoral);
+    assertTrue(optSummary.isPresent());
+    assertTrue(optSummary.get().equalData(ByronMayoral, winnerContest_12, "", "", ""));
+
+    // Check there are some assertions in the database.
+    List<Assertion> assertions = assertionRepository.findByContestName(ByronMayoral);
+    assertFalse(assertions.isEmpty());
+
+    // Make the request with a very short timeout - expected to fail.
+    result = generateAssertionsService.generateAssertions(ByronShortTimeoutRequest);
+
+    assertNull(result.Ok);
+    assertNotNull(result.Err);
+
+    assertInstanceOf(RaireError.TimeoutFindingAssertions.class, result.Err);
+
+    generateAssertionsService.persistAssertionsOrErrors(result, ByronShortTimeoutRequest);
+    optSummary = summaryRepository.findByContestName(ByronMayoral);
+    assertTrue(optSummary.isPresent());
+    assertTrue(optSummary.get().equalData(ByronMayoral, "",
+        TIMEOUT_FINDING_ASSERTIONS.toString(), "", "Time out finding assertions"));
+
+    // Check there are no assertions in the database.
+    assertions = assertionRepository.findByContestName(ByronMayoral);
+    assertEquals(0, assertions.size());
+
+  }
+}

--- a/src/test/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsServiceMultipleCallsTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsServiceMultipleCallsTests.java
@@ -45,6 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+import static au.org.democracydevelopers.raireservice.NSWValues.BallotCount_12;
 import static au.org.democracydevelopers.raireservice.NSWValues.winnerContest_12;
 import static au.org.democracydevelopers.raireservice.service.GenerateAssertionsServiceWickedTests.*;
 import static au.org.democracydevelopers.raireservice.service.RaireServiceException.RaireErrorCode.TIMEOUT_FINDING_ASSERTIONS;
@@ -52,6 +53,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests to validate the behaviour of Assertion generation when called successively.
+ * These are the same as the tests in GenerateAssertionsAPIMultipleCallsTests.java, but call the
+ * service directly instead of (just) the API.
  * Relevant data is preloaded into the test database from
  * src/test/resources/known_testcases_votes.sql.
  * These tests include
@@ -87,8 +90,8 @@ public class GenerateAssertionsServiceMultipleCallsTests {
   /**
    * Second request for Byron, with a normal time limit.
    */
-  final static GenerateAssertionsRequest ByronNormalTimeoutRequest
-      = new GenerateAssertionsRequest(ByronMayoral, 18165, 5,
+  public final static GenerateAssertionsRequest ByronNormalTimeoutRequest
+      = new GenerateAssertionsRequest(ByronMayoral, BallotCount_12, 5,
       choicesByron);
 
   /**

--- a/src/test/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsServiceWickedTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/service/GenerateAssertionsServiceWickedTests.java
@@ -81,7 +81,7 @@ public class GenerateAssertionsServiceWickedTests {
    * Names of contests, to match preloaded data.
    */
   private static final String tiedWinnersContest = "Tied Winners Contest";
-  private static final String ByronMayoral = "Byron Mayoral";
+  static final String ByronMayoral = "Byron Mayoral";
   private static final String timeOutCheckingWinnersContest = "Time out checking winners contest";
   private static final String timeOutTrimmingAssertionsContest = "Time out trimming contest";
 
@@ -89,7 +89,7 @@ public class GenerateAssertionsServiceWickedTests {
    * Candidate lists for the preloaded contests.
    */
   private static final List<String> aliceChuanBob = List.of("Alice", "Chuan", "Bob");
-  private static final List<String> choicesByron = List.of("HUNTER Alan","CLARKE Bruce",
+  static final List<String> choicesByron = List.of("HUNTER Alan","CLARKE Bruce",
       "COOREY Cate","ANDERSON John","MCILRATH Christopher","LYON Michael","DEY Duncan",
       "PUGH Asren","SWIVEL Mark");
   private static final List<String> timeoutCheckingWinnersChoices = List.of("A","B","C","D","E",
@@ -103,7 +103,7 @@ public class GenerateAssertionsServiceWickedTests {
   private final static GenerateAssertionsRequest tiedWinnersRequest
       = new GenerateAssertionsRequest(tiedWinnersContest, 2, 5,
       aliceChuanBob);
-  private final static GenerateAssertionsRequest ByronShortTimeoutRequest
+  final static GenerateAssertionsRequest ByronShortTimeoutRequest
       = new GenerateAssertionsRequest(ByronMayoral, 18165, 0.001,
       choicesByron);
   private final static GenerateAssertionsRequest checkingWinnersTimeoutRequest

--- a/src/test/resources/flipped_example_1.sql
+++ b/src/test/resources/flipped_example_1.sql
@@ -1,0 +1,76 @@
+-- This file is intended to be run after known_testcases_votes.sql.
+-- It substitutes County 9's votes with an edited version of the Guide To Raire Example 1, in which
+-- Alice and Bob are flipped. This allows for testing of proper replacement of assertions.
+
+-- This is what happens when County 9 deletes its CSV export file. Should cascade to cvr_contest_info.
+DELETE FROM cvr_contest_info WHERE county_id = 9;
+DELETE FROM cast_vote_record WHERE county_id = 9;
+
+-- Replace the CVRs.
+-- The Guide To Raire Part 2 Example 1, divided by 500
+-- Chuan and Alice are flipped compared with the example in The Guide and known_testcases_votes.
+-- We expect the assertions to be the same, but to have Chuan and Alice flipped.
+
+-- 10 (C,B,A)
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (1, 1, 'Type 1', 1, 9, '1-1-1', 1, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (1, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (2, 2, 'Type 1', 1, 9, '1-1-2', 2, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (2, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (3, 3, 'Type 1', 1, 9, '1-1-3', 3, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (3, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (4, 4, 'Type 1', 1, 9, '1-1-4', 4, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (4, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (5, 5, 'Type 1', 1, 9, '1-1-5', 5, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (5, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (6, 6, 'Type 1', 1, 9, '1-1-6', 6, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (6, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (7, 7, 'Type 1', 1, 9, '1-1-7', 7, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (7, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (8, 8, 'Type 1', 1, 9, '1-1-8', 8, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (8, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (9, 9, 'Type 1', 1, 9, '1-1-9', 9, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (9, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (10, 10, 'Type 1', 1, 9, '1-1-10', 10, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (10, 9, '["Alice","Bob","Chuan"]', 999991, 0);
+
+-- 2 (B,C,D)
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (11, 11, 'Type 1', 2, 9, '1-2-1', 11, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (11, 9, '["Bob","Alice","Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (12, 12, 'Type 1', 2, 9, '1-2-2', 12, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (12, 9, '["Bob","Alice","Diego"]', 999991, 0);
+
+-- 3 (D,A)
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (13, 13, 'Type 1', 3, 9, '1-3-1', 13, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (13, 9, '["Diego","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (14, 14, 'Type 1', 3, 9, '1-3-2', 14, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (14, 9, '["Diego","Chuan"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (15, 15, 'Type 1', 3, 9, '1-3-3', 15, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (15, 9, '["Diego","Chuan"]', 999991, 0);
+
+-- 8 (A,D)
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (16, 16, 'Type 1', 4, 9, '1-4-1', 16, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (16, 9, '["Chuan","Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (17, 17, 'Type 1', 4, 9, '1-4-2', 17, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (17, 9, '["Chuan","Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (18, 18, 'Type 1', 4, 9, '1-4-3', 18, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (18, 9, '["Chuan","Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (19, 19, 'Type 1', 4, 9, '1-4-4', 19, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (19, 9, '["Chuan","Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (20, 20, 'Type 1', 4, 9, '1-4-5', 20, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (20, 9, '["Chuan","Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (21, 21, 'Type 1', 4, 9, '1-4-6', 21, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (21, 9, '["Chuan","Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (22, 22, 'Type 1', 4, 9, '1-4-7', 22, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (22, 9, '["Chuan","Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (23, 23, 'Type 1', 4, 9, '1-4-8', 23, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (23, 9, '["Chuan","Diego"]', 999991, 0);
+
+-- 4 (D)
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (24, 24, 'Type 1', 5, 9, '1-5-1', 24, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (24, 9, '["Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (25, 25, 'Type 1', 5, 9, '1-5-2', 25, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (25, 9, '["Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (26, 26, 'Type 1', 5, 9, '1-5-3', 26, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (26, 9, '["Diego"]', 999991, 0);
+INSERT INTO cast_vote_record (id, cvr_number, ballot_type, batch_id, county_id, imprinted_id, record_id, record_type, scanner_id) values (27, 27, 'Type 1', 5, 9, '1-5-4', 27, 'UPLOADED', 1);
+INSERT INTO cvr_contest_info (cvr_id, county_id, choices, contest_id, index) values (27, 9, '["Diego"]', 999991, 0);

--- a/src/test/resources/known_testcases_votes.sql
+++ b/src/test/resources/known_testcases_votes.sql
@@ -43,7 +43,7 @@ INSERT INTO contest (county_id, id, version, description, name, sequence_number,
 
 -- CVRs
 
--- The Guide To Raire Example 1, divided by 500
+-- The Guide To Raire Part 2 Example 1, divided by 500
 -- Note that this will _not_ have the same margins as raire-java, because of the divide by 500,
 -- but it should have the same difficulties and assertions.
 


### PR DESCRIPTION
Bug fixed, now with test cases. Also a test that updating the CSVs and re-doing properly replaces the assertions.