### PR TITLE
Remove todos

### DIFF
--- a/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIKnownTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/controller/GenerateAssertionsAPIKnownTests.java
@@ -73,10 +73,6 @@ import org.springframework.transaction.annotation.Transactional;
  * Note for anyone comparing this directly with GenerateAssertionsServiceKnownTests: the
  * test for wrong candidate names is in GenerateAssertionsAPIErrorTests, along with various other
  * tests involving invalid request data.
- * TODO The GenerateAssertionsServiceTest contains tests of proper overwriting when assertion
- * generation is requested but assertions are already in the database. This is not yet complete in
- * this class, pending a decision about how to block assertion regeneration when appropriate.
- * See (<a href="https://github.com/DemocracyDevelopers/raire-service/issues/70">...</a>)
  * In each case, the test
  * - makes a request for assertion generation through the API,
  * - checks for the right winner,

--- a/src/test/java/au/org/democracydevelopers/raireservice/controller/GetAssertionsAPISavedErrorsAndWarningsTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/controller/GetAssertionsAPISavedErrorsAndWarningsTests.java
@@ -121,8 +121,6 @@ public class GetAssertionsAPISavedErrorsAndWarningsTests {
             aliceAndBob, NO_ASSERTIONS_PRESENT, "No assertion generation summary"),
         Arguments.of("CSV", defaultRiskLimit, "No summary but some assertions Contest", defaultCount,
             aliceAndBob, NO_ASSERTIONS_PRESENT, "No assertion generation summary"),
-        // TODO think about the right way of dealing with, and testing, the timeout warning.
-        // See Issue https://github.com/orgs/DemocracyDevelopers/projects/1?pane=issue&itemId=63398709
         Arguments.of("JSON", defaultRiskLimit, "Timeout trimming assertions Contest", defaultCount,
             aliceAndBob, NO_ASSERTIONS_PRESENT, ""),
         Arguments.of("CSV", defaultRiskLimit, "Timeout trimming assertions Contest", defaultCount,

--- a/src/test/java/au/org/democracydevelopers/raireservice/service/GetAssertionsServiceCsvTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/service/GetAssertionsServiceCsvTests.java
@@ -47,8 +47,10 @@ import org.springframework.transaction.annotation.Transactional;
  * - a basic, simple test case with two assertions (NEN and NEB),
  * - a test case with lots of ties, to test that extremum-calculation is correct,
  * - a test case with difficult characters, such as " and ' and , in the candidate names.
- * TODO Note that there are assumptions about how these characters are represented in the database,
+ * TODO - Note that there are assumptions about how these characters are represented in the database,
  * which need to be validated on real data.
+ * See <a href="https://github.com/DemocracyDevelopers/raire-service/issues/96">...</a>
+ * This might actually make more sense as a colorado-rla workflow test.
  */
 @ActiveProfiles("csv-challenges")
 @SpringBootTest
@@ -57,9 +59,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetAssertionsServiceCsvTests {
 
   private static final Logger logger = LoggerFactory.getLogger(GetAssertionsServiceCsvTests.class);
-
-  @Autowired
-  AssertionRepository assertionRepository;
 
   @Autowired
   GetAssertionsCsvService getAssertionsCSVService;
@@ -178,7 +177,7 @@ public class GetAssertionsServiceCsvTests {
     RaireServiceException ex = assertThrows(RaireServiceException.class,
         () -> getAssertionsCSVService.generateCSV(request)
     );
-    assertSame(ex.errorCode, WRONG_CANDIDATE_NAMES);
+    assertSame(WRONG_CANDIDATE_NAMES, ex.errorCode);
   }
 
    /**

--- a/src/test/java/au/org/democracydevelopers/raireservice/service/GetAssertionsServiceCsvTests.java
+++ b/src/test/java/au/org/democracydevelopers/raireservice/service/GetAssertionsServiceCsvTests.java
@@ -24,7 +24,6 @@ import static au.org.democracydevelopers.raireservice.service.RaireServiceExcept
 import static au.org.democracydevelopers.raireservice.testUtils.defaultCount;
 import static org.junit.jupiter.api.Assertions.*;
 
-import au.org.democracydevelopers.raireservice.persistence.repository.AssertionRepository;
 import au.org.democracydevelopers.raireservice.request.GetAssertionsRequest;
 import au.org.democracydevelopers.raireservice.testUtils;
 import java.math.BigDecimal;


### PR DESCRIPTION
This removes all (both) todos except one that's covered explicitly by a TODO card in the project.